### PR TITLE
Add utility to calculate AggregatedDepositStatus for Submission 

### DIFF
--- a/pass-client-util/src/main/java/org/dataconservancy/pass/client/util/StatusUtil.java
+++ b/pass-client-util/src/main/java/org/dataconservancy/pass/client/util/StatusUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.util;
+
+import java.util.Set;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Submission.AggregatedDepositStatus;
+import org.dataconservancy.pass.model.Submission.Source;
+
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.ACCEPTED;
+
+/**
+ * Utility for Status logic 
+ * @author Karen Hanson
+ */
+public class StatusUtil {
+    
+    /**
+     * Calculates the AggregatedDepositStatus based on statuses in current list of Deposits and Submission.source
+     * If deposits are empty or we are missing a required deposit, the status will be NOT_STARTED if source is PASS, otherwise null.
+     * If all deposits are accepted, the status is ACCEPTED
+     * Every other combination of statuses is In Progress
+     * 
+     * @param deposits - Set of Deposits
+     * @param source - the Submission.source value
+     * @return value for Submission.aggregatedDepositStatus
+     */
+    public static AggregatedDepositStatus calcAggregatedDepositStatus(Set<Deposit> deposits, Source source) {
+        if (source==null || !source.equals(Source.PASS)) { //status only needs to be calculated when Submission created through PASS
+            return null;
+        }
+        if (deposits==null || deposits.size()==0) {
+            return AggregatedDepositStatus.NOT_STARTED;
+        }
+        boolean allDepositsAccepted = true;
+        for (Deposit deposit : deposits) {
+            if (deposit==null) {
+                // while null deposit list can indicate no Deposits, a null row suggests something went wrong with the data
+                throw new RuntimeException("A Deposit in the list was null. This may indicate a system problem. Please verify your deposits.");
+            }
+            if (deposit.getDepositStatus()==null || !deposit.getDepositStatus().equals(ACCEPTED)) {
+                allDepositsAccepted = false;
+            }
+        }
+        
+        if (allDepositsAccepted) {
+            return AggregatedDepositStatus.ACCEPTED;
+        } else {
+            return AggregatedDepositStatus.IN_PROGRESS;
+        }
+    }
+    
+}

--- a/pass-client-util/src/test/java/org/dataconservancy/pass/client/util/StatusUtilTest.java
+++ b/pass-client-util/src/test/java/org/dataconservancy/pass/client/util/StatusUtilTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.Submission.AggregatedDepositStatus;
+import org.dataconservancy.pass.model.Submission.Source;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests Status Util
+ * @author Karen Hanson
+ */
+public class StatusUtilTest {
+    
+    private Set<Deposit> deposits = new HashSet<Deposit>();
+    private Deposit deposit1 = new Deposit();
+    private Deposit deposit2 = new Deposit();
+    private Deposit deposit3 = new Deposit();
+    private Deposit deposit4 = new Deposit();    
+    
+    
+    /**
+     * Add deposits in variety of stages of progress, should be IN_PROGRESS in all cases
+     */
+    @Test
+    public void calcSubmissionStatusForDepositsInProgressTest() {
+        deposit1.setDepositStatus(DepositStatus.SUBMITTED);
+        deposits.add(deposit1);        
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS, StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+        
+        deposit2.setDepositStatus(DepositStatus.ACCEPTED);
+        deposits.add(deposit2);
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS, StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+        
+        deposit3.setDepositStatus(DepositStatus.REJECTED);
+        deposits.add(deposit3);
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS, StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));   
+        
+        //should be in progress even if a deposit doesn't have a status for some reason
+        deposit4.setDepositStatus(null);
+        deposits.add(deposit4);
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS, StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));   
+    }
+    
+    
+    /**
+     * Adds 3 deposits, each one accepted, so should have an aggregated status of ACCEPTED
+     * Then adds one that is not accepted to make sure status changes to IN_PROGRESS.
+     */
+    @Test
+    public void calcSubmissionStatusForAcceptedDepositsTest() {
+        deposit1.setDepositStatus(DepositStatus.ACCEPTED);
+        deposits.add(deposit1);
+        
+        assertEquals(AggregatedDepositStatus.ACCEPTED,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+                
+        deposit2.setDepositStatus(DepositStatus.ACCEPTED);
+        deposits.add(deposit2);
+        
+        assertEquals(AggregatedDepositStatus.ACCEPTED,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+        
+        deposit3.setDepositStatus(DepositStatus.ACCEPTED);
+        deposits.add(deposit3);
+        
+        assertEquals(AggregatedDepositStatus.ACCEPTED,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+
+        deposit4.setDepositStatus(DepositStatus.SUBMITTED);
+        deposits.add(deposit4);
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));        
+    }
+
+    
+    /**
+     * Confirms that a null list returns a status of not started
+     */
+    @Test
+    public void calcSubmissionStatusNullListOkTest() {
+        assertEquals(AggregatedDepositStatus.NOT_STARTED,StatusUtil.calcAggregatedDepositStatus(null, Source.PASS));
+    }
+
+
+    /**
+     * Confirms that an empty list returns a status of not started
+     */
+    @Test
+    public void calcSubmissionStatusEmptyListOkTest() {
+        assertEquals(AggregatedDepositStatus.NOT_STARTED,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));  
+    }
+
+
+    /**
+     * Confirms that non-pass submission returns null status
+     */
+    @Test
+    public void calcSubmissionStatusNonPassSourceTest() {
+        assertNull(StatusUtil.calcAggregatedDepositStatus(deposits, null)); 
+        assertNull(StatusUtil.calcAggregatedDepositStatus(deposits, Source.OTHER)); 
+    }
+    
+
+    /**
+     * A null deposit in the list should return an exception, suggests something has gone wrong
+     */
+    @Test(expected=RuntimeException.class)
+    public void calcSubmissionStatusNullDepositNotOkTest() {
+        
+        deposit1.setDepositStatus(DepositStatus.SUBMITTED);
+        deposits.add(deposit1);        
+        
+        assertEquals(AggregatedDepositStatus.IN_PROGRESS,StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS));
+        
+        deposits.add(null);
+        //should throw exception
+        StatusUtil.calcAggregatedDepositStatus(deposits, Source.PASS);
+        
+    }
+    
+}


### PR DESCRIPTION
Different Java projects will need to perform the new logic in StatusUtil, so I added it to the client.
For Submissions whose source is not PASS, an AggregatedDepositStatus of null is returned.
Where the source is PASS, using the list of Deposits the method takes the status of each and calculates the Submission.AggregatedDepositStatus from it.