### PR TITLE
Allow null attribute values in queries

### DIFF
--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.dataconservancy.pass.model.Deposit;
 import org.junit.Test;
 
 import org.dataconservancy.pass.model.File;
@@ -158,7 +159,28 @@ public class FindAllByAttributeIT extends ClientITBase {
         }
     }
 
-    
+    @Test
+    public void testFindDepositWithNoStatus() throws Exception {
+        Deposit deposit = random(Deposit.class, 1);
+        deposit.setDepositStatus(null);
+        URI expectedUri = client.createResource(deposit);
+
+        try {
+            attempt(20, () -> {
+                assertEquals(expectedUri.getPath(),
+                        client.findByAttribute(Deposit.class, "@id", expectedUri).getPath());
+            });
+
+            assertEquals(expectedUri.getPath(),
+                    client.findByAttribute(Deposit.class, "depositStatus", null).getPath());
+            Set<URI> deposits = client.findAllByAttribute(Deposit.class, "depositStatus", null);
+            assertEquals(1, deposits.size());
+            assertEquals(expectedUri.getPath(), deposits.iterator().next().getPath());
+        } finally {
+            client.deleteResource(expectedUri);
+        }
+    }
+
     /**
      * Check findAllByAttribute rejects a value that is a collection
      */

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
@@ -128,6 +128,9 @@ public class FindAllByAttributesIT extends ClientITBase {
         submission2.setUser(user);
         URI expectedUri3 = client.createResource(submission3);
 
+        Deposit deposit1 = random(Deposit.class, 1);
+        URI expectedUri4 = client.createResource(deposit1);
+
         try {
             attempt(30, () -> {
                 assertEquals(expectedUri1.getPath(),
@@ -136,6 +139,8 @@ public class FindAllByAttributesIT extends ClientITBase {
                         client.findByAttribute(Submission.class, "@id", expectedUri2).getPath());
                 assertEquals(expectedUri3.getPath(),
                         client.findByAttribute(Submission.class, "@id", expectedUri3).getPath());
+                assertEquals(expectedUri4.getPath(),
+                        client.findByAttribute(Deposit.class, "@id", expectedUri4).getPath());
             });
 
             Set<URI> uris = client.findAllByAttributes(Submission.class, new HashMap<String, Object>() {{
@@ -144,12 +149,26 @@ public class FindAllByAttributesIT extends ClientITBase {
                 put("user", user);
             }});
 
+            // Only the two Submissions with null sources should be found.  The other Submission has a non-null source,
+            // and the other resource is a Deposit.
+            assertEquals(2, uris.size());
+            assertTrue(uris.stream().anyMatch(uri -> uri.getPath().equals(expectedUri1.getPath())));
+            assertTrue(uris.stream().anyMatch(uri -> uri.getPath().equals(expectedUri2.getPath())));
+
+            uris = client.findAllByAttributes(Submission.class, new HashMap<String, Object>() {{
+                put("source", null);
+            }});
+
+            // Only two Submissions with null sources should be found. The other Submission has a non-null source, and
+            // the other resource is a Deposit.
             assertEquals(2, uris.size());
             assertTrue(uris.stream().anyMatch(uri -> uri.getPath().equals(expectedUri1.getPath())));
             assertTrue(uris.stream().anyMatch(uri -> uri.getPath().equals(expectedUri2.getPath())));
         } finally {
             client.deleteResource(expectedUri1);
             client.deleteResource(expectedUri2);
+            client.deleteResource(expectedUri3);
+            client.deleteResource(expectedUri4);
         }
     }
     


### PR DESCRIPTION
Use case: deposit services needs to be able to find `Deposit` resources that do _not_ carry a `depositStatus`.  

This patch adds the capability for clients to search for documents in the index that do not carry a specified attribute by setting the value to `null` in the query.