### PR TITLE
Replace PUT with PATCH on Fedora updates

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-api</artifactId>
   <name>pass-client-api</name>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -100,7 +100,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:latest</name>
+              <name>oapass/indexer:0.0.5-2.0-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-2</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-integration</artifactId>
 

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-2</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateReadResourceRoundTripIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateReadResourceRoundTripIT.java
@@ -17,6 +17,7 @@
 package org.dataconservancy.pass.client.integration;
 
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
+import java.net.URI;
 
 import org.dataconservancy.pass.model.PassEntity;
 import org.junit.Test;
@@ -66,11 +67,15 @@ public class CreateReadResourceRoundTripIT extends ClientITBase {
     }
 
     void roundTrip(PassEntity asDeposited) {
-
-        final PassEntity retrieved = client.readResource(client.createResource(asDeposited), asDeposited.getClass());
-
-        assertReflectionEquals(normalized(asDeposited), normalized(retrieved),
-                ReflectionComparatorMode.LENIENT_ORDER);
-
+        final URI entityUri = client.createResource(asDeposited);   
+        try {
+            final PassEntity retrieved = client.readResource(entityUri, asDeposited.getClass());
+            assertReflectionEquals(normalized(asDeposited), normalized(retrieved),
+                                   ReflectionComparatorMode.LENIENT_ORDER);
+        } finally {
+            if (entityUri!=null) {
+                client.deleteResource(entityUri);
+            }
+        }
     }
 }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
@@ -118,7 +118,7 @@ public class FindAllByAttributeIT extends ClientITBase {
             
             final URI searchUri = uri;
             
-            attempt(20, () -> { //make sure last one is in the index
+            attempt(RETRIES, () -> { //make sure last one is in the index
                 final URI matchedUri = client.findByAttribute(File.class, "@id", searchUri);
                 assertEquals(searchUri, matchedUri);
             }); 
@@ -166,7 +166,7 @@ public class FindAllByAttributeIT extends ClientITBase {
         URI expectedUri = client.createResource(deposit);
 
         try {
-            attempt(20, () -> {
+            attempt(RETRIES, () -> {
                 assertEquals(expectedUri.getPath(),
                         client.findByAttribute(Deposit.class, "@id", expectedUri).getPath());
             });
@@ -177,7 +177,10 @@ public class FindAllByAttributeIT extends ClientITBase {
             assertEquals(1, deposits.size());
             assertEquals(expectedUri.getPath(), deposits.iterator().next().getPath());
         } finally {
-            client.deleteResource(expectedUri);
+            Set <URI> matches = client.findAllByAttribute(Deposit.class, "depositStatus", null);
+            for (URI match : matches) {
+                client.deleteResource(match);
+            }
         }
     }
 

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
@@ -132,7 +132,6 @@ public class FindAllByAttributesIT extends ClientITBase {
         URI expectedUri4 = client.createResource(deposit1);
 
         try {
-            attempt(30, () -> {
                 assertEquals(expectedUri1.getPath(),
                         client.findByAttribute(Submission.class, "@id", expectedUri1).getPath());
                 assertEquals(expectedUri2.getPath(),
@@ -141,6 +140,7 @@ public class FindAllByAttributesIT extends ClientITBase {
                         client.findByAttribute(Submission.class, "@id", expectedUri3).getPath());
                 assertEquals(expectedUri4.getPath(),
                         client.findByAttribute(Deposit.class, "@id", expectedUri4).getPath());
+            attempt(RETRIES, () -> {
             });
 
             Set<URI> uris = client.findAllByAttributes(Submission.class, new HashMap<String, Object>() {{
@@ -206,7 +206,7 @@ public class FindAllByAttributesIT extends ClientITBase {
             matches = client.findAllByAttributes(Deposit.class, attribs, 4, 8);
             assertEquals(2, matches.size());
         } finally {
-            Set <URI> matches = client.findAllByAttributes(Deposit.class, attribs);
+            Set <URI> matches = client.findAllByAttributes(Deposit.class, attribs, 20, 0);
             for (URI match : matches) {
                 client.deleteResource(match);
             }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
@@ -132,6 +132,7 @@ public class FindAllByAttributesIT extends ClientITBase {
         URI expectedUri4 = client.createResource(deposit1);
 
         try {
+            attempt(30, () -> {
                 assertEquals(expectedUri1.getPath(),
                         client.findByAttribute(Submission.class, "@id", expectedUri1).getPath());
                 assertEquals(expectedUri2.getPath(),
@@ -140,7 +141,6 @@ public class FindAllByAttributesIT extends ClientITBase {
                         client.findByAttribute(Submission.class, "@id", expectedUri3).getPath());
                 assertEquals(expectedUri4.getPath(),
                         client.findByAttribute(Deposit.class, "@id", expectedUri4).getPath());
-            attempt(RETRIES, () -> {
             });
 
             Set<URI> uris = client.findAllByAttributes(Submission.class, new HashMap<String, Object>() {{

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
@@ -50,7 +50,7 @@ public class FindByAttributeIT extends ClientITBase {
     public void testMixedCaseAwardNumber() throws Exception {
 
         Grant grant = random(Grant.class, 1);
-        URI grantId = client.createResource(grant);
+        final URI grantId = client.createResource(grant);
 
         try {
             attempt(RETRIES, () -> { // check the record exists before continuing
@@ -122,7 +122,7 @@ public class FindByAttributeIT extends ClientITBase {
     @Test
     public void testNoMatchFound() {
         Grant grant = random(Grant.class, 1);
-        URI grantId = client.createResource(grant); //create something so it's not empty
+        final URI grantId = client.createResource(grant); //create something so it's not empty
         try {
             attempt(RETRIES, () -> {
                 final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
@@ -144,7 +144,7 @@ public class FindByAttributeIT extends ClientITBase {
     @Test
     public void testMultiRowArraySearch() {
         Submission submission = random(Submission.class, 2); //create random submission where each list has 2 rows
-        URI submissionId = client.createResource(submission);
+        final URI submissionId = client.createResource(submission);
         try {
             attempt(RETRIES, () -> {
                 final URI uri = client.findByAttribute(Submission.class, "@id", submissionId);

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/TestUserModel.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/TestUserModel.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.integration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.dataconservancy.pass.model.PassEntity;
+import org.dataconservancy.pass.model.PassEntityType;
+
+/**
+ * This is a cut down copy of the User model. It is used to verify that by using PATCH for updates
+ * we do not lose data when using a cut down model
+ * 
+ * @author Karen Hanson
+ */
+public class TestUserModel extends PassEntity {
+
+    /** 
+     * This will pretend it is a "User" object for testing.
+     */
+    @JsonProperty("@type")
+    private String type = PassEntityType.USER.getName();
+    
+    /** 
+     * Unique login name used by user 
+     */
+    private String username;
+
+    /** 
+     * Name for display. Separate names may not be available, but a person should always at least 
+     * have a display name.
+     */
+    private String displayName; 
+    
+    /** 
+     * Contact email for User
+     */
+    private String email;
+    
+    
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    
+    /**
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    
+    /**
+     * @param username the username to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    
+    /**
+     * @param displayName the displayName to set
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    
+    /**
+     * @return the email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    
+    /**
+     * @param email the email to set
+     */
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        TestUserModel that = (TestUserModel) o;
+
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        if (username != null ? !username.equals(that.username) : that.username != null) return false;
+        if (displayName != null ? !displayName.equals(that.displayName) : that.displayName != null) return false;
+        if (email != null ? !email.equals(that.email) : that.email != null) return false;
+        return true;
+    }
+
+    
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (username != null ? username.hashCode() : 0);
+        result = 31 * result + (displayName != null ? displayName.hashCode() : 0);
+        result = 31 * result + (email != null ? email.hashCode() : 0);
+        return result;
+    }
+    
+
+}

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
@@ -117,23 +117,21 @@ public class UpdateResourceIT extends ClientITBase {
     }
 
     void createAndUpdate(PassEntity toDeposit, PassEntity updatedContent) {
-
-        final PassEntity intermediate = client.readResource(client.createResource(toDeposit), toDeposit.getClass());
+        final URI passEntityUri = client.createResource(toDeposit);
 
         try {
-            final URI id = intermediate.getId();
+            final PassEntity intermediate = client.readResource(passEntityUri, toDeposit.getClass());
             BeanUtils.copyProperties(intermediate, updatedContent);
-            intermediate.setId(id);
+            intermediate.setId(passEntityUri);
+            client.updateResource(intermediate);
+            final PassEntity asUpdated = client.readResource(passEntityUri, intermediate.getClass());
+            assertReflectionEquals(normalized(updatedContent), normalized(asUpdated),
+                                   ReflectionComparatorMode.LENIENT_ORDER);
         } catch (final Exception e) {
             throw new RuntimeException(e);
+        } finally { 
+            client.deleteResource(passEntityUri);
         }
-
-        client.updateResource(intermediate);
-
-        final PassEntity asUpdated = client.readResource(intermediate.getId(), intermediate.getClass());
-
-        assertReflectionEquals(normalized(updatedContent), normalized(asUpdated),
-                ReflectionComparatorMode.LENIENT_ORDER);
 
     }
 }

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-util</artifactId>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-data-client</artifactId>
   <name>PASS Data Client</name>

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -47,6 +47,7 @@ public class FedoraPassCrudClient {
     private static final Logger LOG = LoggerFactory.getLogger(FedoraPassCrudClient.class);
 
     private final static String JSONLD_CONTENTTYPE = "application/ld+json; charset=utf-8";
+    private final static String JSONLD_PATCH_CONTENTTYPE = "application/merge-patch+json; charset=utf-8";
     private final static String SERVER_MANAGED_OMITTYPE = "http://fedora.info/definitions/v4/repository#ServerManaged";
     private final static String COMPACTED_ACCEPTTYPE = "application/ld+json";
     
@@ -114,22 +115,19 @@ public class FedoraPassCrudClient {
     /**
      * @see org.dataconservancy.pass.client.PassClient#updateResource(PassEntity)
      */
-    public URI updateResource(PassEntity modelObj) {
-        URI updatedId = null;
-        
+    public void updateResource(PassEntity modelObj) {
         byte[] json = adapter.toJson(modelObj, true);
         InputStream jsonIS = new ByteArrayInputStream(json);
         
-        try (FcrepoResponse response = client.put(modelObj.getId())
-                .body(jsonIS, JSONLD_CONTENTTYPE)
-                .preferLenient()
-                .perform()) {
-            updatedId = response.getLocation();
-            LOG.info("Container update status and location: {}, {}", response.getStatusCode(), updatedId);
+        PatchBuilderExtension patchbuilder = new PatchBuilderExtension(modelObj.getId(), client);
+        try (FcrepoResponse response = patchbuilder
+                            .body(jsonIS, JSONLD_PATCH_CONTENTTYPE)
+                            .preferLenient()
+                            .perform()) {
+            LOG.info("Container update status and location: {}, {}", response.getStatusCode(), modelObj.getId());
         } catch (IOException | FcrepoOperationFailedException e) {
             throw new RuntimeException("A problem occurred while attempting to update a Resource", e);
         }
-        return updatedId;
     }
 
     /**

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -122,7 +122,6 @@ public class FedoraPassCrudClient {
         PatchBuilderExtension patchbuilder = new PatchBuilderExtension(modelObj.getId(), client);
         try (FcrepoResponse response = patchbuilder
                             .body(jsonIS, JSONLD_PATCH_CONTENTTYPE)
-                            .preferLenient()
                             .perform()) {
             LOG.info("Container update status and location: {}, {}", response.getStatusCode(), modelObj.getId());
         } catch (IOException | FcrepoOperationFailedException e) {

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/PatchBuilderExtension.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/PatchBuilderExtension.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.fedora;
+
+
+import java.io.InputStream;
+
+import java.net.URI;
+
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.PatchBuilder;
+
+import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
+
+/**
+ * The org.fcrepo.client.PatchBuilder class does not currently have several features needed
+ * to perform a PATCH operation in which you can define the content type and add the "prefer lenient"
+ * header. This extends the PatchBuilder to include these for use on FedoraPassCrudClient.updateResource()
+ * @author Karen Hanson
+ */
+public class PatchBuilderExtension extends PatchBuilder {
+
+    /**
+     * Instantiate builder
+     * 
+     * @param uri uri of the resource this request is being made to
+     * @param client the client
+     */
+    public PatchBuilderExtension(final URI uri, final FcrepoClient client) {
+        super(uri, client);
+    }
+
+    @Override
+    public PatchBuilderExtension body(final InputStream stream, final String contentType) {
+        return (PatchBuilderExtension) super.body(stream, contentType);
+    }
+
+    /**
+     * Set the prefer header for this request to lenient handling, to indicate that server-managed triples will not
+     * be included in the request body.
+     *
+     * @return this builder
+     */
+    public PatchBuilderExtension preferLenient() {
+        request.setHeader(PREFER, "handling=lenient; received=\"minimal\"");
+        return this;
+    }
+}

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/PatchBuilderExtension.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/PatchBuilderExtension.java
@@ -23,12 +23,10 @@ import java.net.URI;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.PatchBuilder;
 
-import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
-
 /**
  * The org.fcrepo.client.PatchBuilder class does not currently have several features needed
- * to perform a PATCH operation in which you can define the content type and add the "prefer lenient"
- * header. This extends the PatchBuilder to include these for use on FedoraPassCrudClient.updateResource()
+ * to perform a PATCH operation in which you can define the content type header. This extends the 
+ * PatchBuilder to include these for use on FedoraPassCrudClient.updateResource()
  * @author Karen Hanson
  */
 public class PatchBuilderExtension extends PatchBuilder {
@@ -47,15 +45,5 @@ public class PatchBuilderExtension extends PatchBuilder {
     public PatchBuilderExtension body(final InputStream stream, final String contentType) {
         return (PatchBuilderExtension) super.body(stream, contentType);
     }
-
-    /**
-     * Set the prefer header for this request to lenient handling, to indicate that server-managed triples will not
-     * be included in the request body.
-     *
-     * @return this builder
-     */
-    public PatchBuilderExtension preferLenient() {
-        request.setHeader(PREFER, "handling=lenient; received=\"minimal\"");
-        return this;
-    }
+    
 }

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-json-adapter</artifactId>
   

--- a/pass-json-adapter/src/test/java/org/dataconservancy/pass/client/adapter/JsonAdapterTests.java
+++ b/pass-json-adapter/src/test/java/org/dataconservancy/pass/client/adapter/JsonAdapterTests.java
@@ -31,6 +31,7 @@ import org.dataconservancy.pass.model.TestValues;
 import org.json.JSONObject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -90,6 +91,36 @@ public class JsonAdapterTests {
         assertEquals(root.getString("submission"),TestValues.SUBMISSION_ID_1); 
         assertEquals(root.getString("repository"),TestValues.REPOSITORY_ID_1); 
         assertEquals(root.getString("repositoryCopy"),TestValues.REPOSITORYCOPY_ID_1); 
+    }
+
+
+    /**
+     * Verify that we can convert a model object to JSON with JSONLD context
+     * and that null values are included in the JSON
+     * @throws Exception
+     */
+    @Test
+    public void testDepositToJsonWithContextIncludeNulls() throws Exception {
+        
+        Deposit deposit = createDeposit();
+        deposit.setDepositStatusRef(null);
+        deposit.setRepositoryCopy(null);
+        
+        PassJsonAdapter adapter = new PassJsonAdapterBasic();
+        String jsonDeposit = new String(adapter.toJson(deposit, true));
+        
+        JSONObject root = new JSONObject(jsonDeposit);
+
+        assertEquals(root.getString("@id"),TestValues.DEPOSIT_ID_1.toString());
+        assertEquals(root.getString("@type"),PassEntityType.DEPOSIT.getName());
+        assertEquals(root.getString("@context"),CONTEXT);
+        assertEquals(root.getString("depositStatus"),TestValues.DEPOSIT_STATUS);
+        assertTrue(root.has("depositStatusRef")); 
+        assertEquals(root.get("depositStatusRef"),null); 
+        assertEquals(root.getString("submission"),TestValues.SUBMISSION_ID_1); 
+        assertEquals(root.getString("repository"),TestValues.REPOSITORY_ID_1);
+        assertTrue(root.has("repositoryCopy"));  
+        assertEquals(root.get("repositoryCopy"),null); 
     }
 
     

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-model</artifactId>
   <name>PASS Core Data Model</name>

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * a unique ID, type, and context
  * @author Karen Hanson
  */
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class PassEntity {
     
@@ -34,12 +34,14 @@ public abstract class PassEntity {
      * Unique URI for the resource. This corresponds to the URI of this resource in the 
      * repository. This URI can be used to retrieve the resource from the repository 
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("@id")
     protected URI id;
     
     /** 
      * Optional context field, when present this can be used to convert the JSON to JSON-LD
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("@context")
     protected String context = null;
     

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-test-data</artifactId>
   <name>PASS Test Data</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   
   <name>PASS Client Tool</name>
   


### PR DESCRIPTION
Changed to use PATCH instead of PUT in Fedora Client. To support this change:
* Modified the Jackson annotations in the data model to make null values be included in the JSON output. The exceptions to this are the `@id` field, and the `@context` field, both of which should sometimes be excluded from the JSON for legitimate reasons.
* Extended the FcrepoClient's PatchBuilder class to support definition of content type, configured it to indicate type for patch merge
* Changed integration test to use `oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1` which contains the PATCH support
* Added a test to the JSON adapter to make sure NULLs are being reflected in the JSON output.
* Added an integration test to check PATCH is merging on update as it should.

Also improved cleanup of tests, since remaining data was causing problems during ITs.

Finally, removed return value for Fedora CRUD client's updateResource() - it does not have one on the interfaces

Closes #9 