### PR TITLE
Updates PassClient to expose the incoming links for a URI.

### DIFF
--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.client;
 
 import java.net.URI;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -183,6 +184,18 @@ public interface PassClient {
      * @return
      */
     public <T extends PassEntity> Set<URI> findAllByAttributes(Class<T> modelClass, Map<String, Object> attributeValuesMap, int limit, int offset);
+
+    /**
+     * Retrieve inbound links to the repository resource identified by {@code passEntity}.
+     * <p>
+     * Keys in the returned map will be the predicate, and values will be the incoming URIs that reference the
+     * {@code passEntity}.
+     * </p>
+     *
+     * @param passEntity the URI of a repository resource
+     * @return a {@code Map} keyed by predicate, may be empty but never {@code null}
+     */
+    public Map<String, Collection<URI>> getIncoming(URI passEntity);
 
     
 }

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -100,7 +100,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.5-2.0-SNAPSHOT</name>
+              <name>oapass/indexer:0.0.6-2.0-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
@@ -50,7 +50,7 @@ import static com.openpojo.reflection.impl.PojoClassFactory.enumerateClassesByEx
  */
 public abstract class ClientITBase {
 
-    protected static final int RETRIES = 10;
+    protected static final int RETRIES = 60;
     
     static {
         if (System.getProperty("pass.fedora.baseurl") == null) {

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/IncomingLinksIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/IncomingLinksIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.integration;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.File;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Insures that the {@link PassClient} can retrieve incoming links, and that callers can successfully sniff the types
+ * of the incoming links.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class IncomingLinksIT extends ClientITBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IncomingLinksIT.class);
+
+    private String expectedPredicate = "submission";
+
+    private Submission submission;
+
+    private File file;
+
+    private Deposit depositOne;
+
+    private Deposit depositTwo;
+
+    private Submission submissionNoIncoming;
+
+    @Before
+    public void setUp() throws Exception {
+
+        // Add a Submission
+        submission = new Submission();
+        submission.setSource(Submission.Source.PASS);
+        submission = client.readResource(client.createResource(submission), Submission.class);
+
+        submissionNoIncoming = new Submission();
+        submissionNoIncoming.setSource(Submission.Source.PASS);
+        submissionNoIncoming = client.readResource(client.createResource(submissionNoIncoming), Submission.class);
+
+        // Add a File that references the Submission
+        file = new File();
+        file.setName("FileReferencingSubmission");
+        file.setSubmission(submission.getId());
+        file = client.readResource(client.createResource(file), File.class);
+
+        // Add two Deposits that reference the Submission
+        depositOne = new Deposit();
+        depositOne.setDepositStatusRef("http://reference/to/deposit/status/1");
+        depositOne.setSubmission(submission.getId());
+        depositOne = client.readResource(client.createResource(depositOne), Deposit.class);
+
+        depositTwo = new Deposit();
+        depositTwo.setDepositStatusRef("http://reference/to/deposit/status/2");
+        depositTwo.setSubmission(submission.getId());
+        depositTwo = client.readResource(client.createResource(depositTwo), Deposit.class);
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.deleteResource(submission.getId());
+        client.deleteResource(submissionNoIncoming.getId());
+        client.deleteResource(file.getId());
+        client.deleteResource(depositOne.getId());
+        client.deleteResource(depositTwo.getId());
+    }
+
+    /**
+     * Expect three incoming links to the Submission, with the predicate "submission".
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getIncoming() throws Exception {
+        Map<String, Collection<URI>> incomingLinks = client.getIncoming(submission.getId());
+        assertNotNull("Returned map must never be null.", incomingLinks);
+        assertTrue("Map expected to contain predicate '" + expectedPredicate + "'",
+                incomingLinks.containsKey(expectedPredicate));
+
+        Collection<URI> incomingSubmissionLinks = incomingLinks.get("submission");
+        assertEquals("Map expected to contain three incoming URIs for predicate '" + expectedPredicate + "'",
+                3, incomingSubmissionLinks.size());
+        assertTrue(incomingSubmissionLinks.contains(file.getId()));
+        assertTrue(incomingSubmissionLinks.contains(depositOne.getId()));
+        assertTrue(incomingSubmissionLinks.contains(depositTwo.getId()));
+    }
+
+    /**
+     * Expect no incoming links to the Submission, result should be an empty map.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getGetIncomingNonExisting() throws Exception {
+        Map<String, Collection<URI>> incomingLinks = client.getIncoming(submissionNoIncoming.getId());
+        assertNotNull("Returned map must never be null.", incomingLinks);
+        assertTrue(incomingLinks.isEmpty());
+    }
+
+    /**
+     * Insure that the types of the incoming links can be reliably sniffed by callers.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void typeSniffing() throws Exception {
+        Map<String, Collection<URI>> incomingLinks = client.getIncoming(submission.getId());
+        Set<File> files = incomingLinks.get(expectedPredicate).stream().map((uri) -> {
+            try {
+                return client.readResource(uri, File.class);
+            } catch (Exception e) {
+                LOG.error("Error reading resource {}: {}", uri, e.getMessage(), e);
+                return null;
+            }
+        }).collect(HashSet::new, (set, file) -> {
+            if (file != null) {
+                set.add(file);
+            }
+        }, HashSet::addAll);
+
+        assertEquals(1, files.size());
+        assertEquals(file.getId(), files.iterator().next().getId());
+
+        Set<Deposit> deposits = incomingLinks.get(expectedPredicate).stream().map((uri) -> {
+            try {
+                return client.readResource(uri, Deposit.class);
+            } catch (Exception e) {
+                LOG.error("Error reading resource {}: {}", uri, e.getMessage(), e);
+                return null;
+            }
+        }).collect(HashSet::new, (set, deposit) -> {
+            if (deposit != null) {
+                set.add(deposit);
+            }
+        }, HashSet::addAll);
+
+        assertEquals(2, deposits.size());
+        assertTrue(deposits.stream().anyMatch(d -> d.getId().equals(depositOne.getId())));
+        assertTrue(deposits.stream().anyMatch(d -> d.getId().equals(depositTwo.getId())));
+    }
+}

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/TestUserModel.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/TestUserModel.java
@@ -51,7 +51,6 @@ public class TestUserModel extends PassEntity {
     private String email;
     
     
-    @Override
     public String getType() {
         return type;
     }

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.client;
 
 import java.net.URI;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -76,6 +77,11 @@ public class PassClientDefault implements PassClient {
     @Override
     public <T extends PassEntity> T readResource(URI uri, Class<T> modelClass) {
         return crudClient.readResource(uri, modelClass);
+    }
+
+    @Override
+    public Map<String, Collection<URI>> getIncoming(URI passEntity) {
+        return crudClient.getIncoming(passEntity);
     }
 
     /**

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -23,8 +23,15 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dataconservancy.pass.client.PassJsonAdapter;
 import org.dataconservancy.pass.client.adapter.PassJsonAdapterBasic;
 import org.dataconservancy.pass.model.PassEntity;
@@ -50,6 +57,7 @@ public class FedoraPassCrudClient {
     private final static String JSONLD_PATCH_CONTENTTYPE = "application/merge-patch+json; charset=utf-8";
     private final static String SERVER_MANAGED_OMITTYPE = "http://fedora.info/definitions/v4/repository#ServerManaged";
     private final static String COMPACTED_ACCEPTTYPE = "application/ld+json";
+    private final static String INCOMING_INCLUDETYPE = "http://fedora.info/definitions/v4/repository#InboundReferences";
     
     /** 
      * The Fedora client tool 
@@ -166,5 +174,58 @@ public class FedoraPassCrudClient {
         }        
     }
 
+    /**
+     * @see org.dataconservancy.pass.client.PassClient#getIncoming(URI)
+     */
+    public Map<String, Collection<URI>> getIncoming(URI passEntityUri) {
+        List<URI> include = Collections.singletonList(URI.create(INCOMING_INCLUDETYPE));
+        List<URI> omits = Collections.singletonList(URI.create(SERVER_MANAGED_OMITTYPE));
+
+        try (FcrepoResponse response = new GetBuilder(passEntityUri, client)
+                .accept(COMPACTED_ACCEPTTYPE)
+                .preferRepresentation(include, omits)
+                .perform()) {
+
+            LOG.info("Resource read status: {}", response.getStatusCode());
+
+            JsonNode raw = new ObjectMapper().readTree(response.getBody());
+            JsonNode graph = raw.withArray("@graph");
+
+            if (graph == null || graph.size() < 1) {
+                return Collections.emptyMap();
+            }
+
+            Map<String, Collection<URI>> result = new ConcurrentHashMap<>();
+
+            graph.elements().forEachRemaining((node) -> {
+                if (!node.has("@id")) {
+                    return;
+                }
+
+                URI incomingLink = URI.create(node.get("@id").asText());
+
+                // Filter out any nodes in the graph that refer to the requested PASS entity
+                // Remaining nodes in the graph are incoming links
+                if (passEntityUri.toString().equals(incomingLink.toString())) {
+                    return;
+                }
+
+                node.fieldNames().forEachRemaining(field -> {
+                    if ("@id".equals(field)) {
+                        return;
+                    }
+
+                    Collection<URI> uris = result.getOrDefault(field, new HashSet<>());
+                    uris.add(incomingLink);
+                    result.putIfAbsent(field, uris);
+                });
+            });
+
+            return result;
+
+        } catch (IOException | FcrepoOperationFailedException e) {
+            throw new RuntimeException("A problem occurred while attempting to read a Resource", e);
+        }
+    }
     
 }

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -93,7 +93,7 @@ public class FedoraPassCrudClient {
         URI newId = null;
         
         try {            
-            container = new URI(FedoraConfig.getContainer(modelObj.getType()));
+            container = new URI(FedoraConfig.getContainer(modelObj.getClass().getSimpleName()));
         } catch (URISyntaxException e) {
             throw new RuntimeException("Container name could not be converted to a URI", e);
         }

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
@@ -35,7 +35,6 @@ public class Contributor extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.CONTRIBUTOR.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
@@ -31,11 +31,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Contributor extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.CONTRIBUTOR.getName();
     
     /** 
      * First name(s) of person 
@@ -130,14 +125,6 @@ public class Contributor extends PassEntity {
             return this.value;
         }
     }
-    
-    
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-    
     
     /**
      * @return the firstName
@@ -307,7 +294,6 @@ public class Contributor extends PassEntity {
 
         Contributor that = (Contributor) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
         if (middleName != null ? !middleName.equals(that.middleName) : that.middleName != null) return false;
         if (lastName != null ? !lastName.equals(that.lastName) : that.lastName != null) return false;
@@ -325,7 +311,6 @@ public class Contributor extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
         result = 31 * result + (middleName != null ? middleName.hashCode() : 0);
         result = 31 * result + (lastName != null ? lastName.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -29,11 +30,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Deposit extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.DEPOSIT.getName();
     
     /** 
      * A URL or some kind of reference that can be dereferenced, entity body parsed, and used to determine the status of Deposit
@@ -105,13 +101,6 @@ public class Deposit extends PassEntity {
         }
         
     }
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-    
     
     /**
      * @return the deposit status
@@ -201,7 +190,6 @@ public class Deposit extends PassEntity {
 
         Deposit that = (Deposit) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (depositStatusRef != null ? !depositStatusRef.equals(that.depositStatusRef) : that.depositStatusRef != null) return false;
         if (depositStatus != null ? !depositStatus.equals(that.depositStatus) : that.depositStatus != null) return false;
         if (submission != null ? !submission.equals(that.submission) : that.submission != null) return false;
@@ -214,7 +202,6 @@ public class Deposit extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (depositStatusRef != null ? depositStatusRef.hashCode() : 0);
         result = 31 * result + (depositStatus != null ? depositStatus.hashCode() : 0);
         result = 31 * result + (submission != null ? submission.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
@@ -33,7 +33,6 @@ public class Deposit extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.DEPOSIT.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
@@ -21,18 +21,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * Files are associated with a Submissions to be used to form Deposits into Repositories
  * @author Karen Hanson
  */
-
 public class File extends PassEntity {
 
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.FILE.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
@@ -28,11 +28,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Karen Hanson
  */
 public class File extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.FILE.getName();
     
     /** 
      * Name of file, defaults to filesystem.name 
@@ -99,14 +94,6 @@ public class File extends PassEntity {
             return this.value;
         }
     }
-    
-    
-
-    @Override
-    public String getType() {
-        return type;
-    }
-        
     
     /**
      * @return the name
@@ -212,7 +199,6 @@ public class File extends PassEntity {
 
         File that = (File) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (uri != null ? !uri.equals(that.uri) : that.uri != null) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
@@ -226,7 +212,6 @@ public class File extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (uri != null ? uri.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/File.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * Files are associated with a Submissions to be used to form Deposits into Repositories

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
@@ -27,11 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Funder extends PassEntity {
 
     /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.FUNDER.getName();
-    
-    /** 
      * Funder name 
      */
     private String name;
@@ -51,13 +46,7 @@ public class Funder extends PassEntity {
      * PASS and a local system. In the case of JHU this is the key assigned in COEUS
      */
     private String localKey;
-    
-    @Override
-    public String getType() {
-        return type;
-    }
 
-    
     /**
      * @return the name
      */
@@ -131,7 +120,6 @@ public class Funder extends PassEntity {
 
         Funder that = (Funder) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (url != null ? !url.equals(that.url) : that.url != null) return false;
         if (policy != null ? !policy.equals(that.policy) : that.policy != null) return false;
@@ -143,7 +131,6 @@ public class Funder extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (url != null ? url.hashCode() : 0);
         result = 31 * result + (policy != null ? policy.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
@@ -29,7 +29,6 @@ public class Funder extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.FUNDER.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Funder.java
@@ -17,8 +17,6 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * The funder or sponsor of Grant or award.
  * @author Karen Hanson

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Grant.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Grant.java
@@ -40,7 +40,6 @@ public class Grant extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.GRANT.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Grant.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Grant.java
@@ -36,11 +36,6 @@ import org.joda.time.DateTime;
  */
 
 public class Grant extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.GRANT.getName();
     
     /** 
      * Award number from funder 
@@ -133,13 +128,6 @@ public class Grant extends PassEntity {
             return this.value;
         }
     }
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-
     
     /**
      * @return the awardNumber
@@ -324,7 +312,6 @@ public class Grant extends PassEntity {
 
         Grant that = (Grant) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (awardNumber != null ? !awardNumber.equals(that.awardNumber) : that.awardNumber != null) return false;
         if (awardStatus != null ? !awardStatus.equals(that.awardStatus) : that.awardStatus != null) return false;
         if (localKey != null ? !localKey.equals(that.localKey) : that.localKey != null) return false;
@@ -344,7 +331,6 @@ public class Grant extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (awardNumber != null ? awardNumber.hashCode() : 0);
         result = 31 * result + (awardStatus != null ? awardStatus.hashCode() : 0);
         result = 31 * result + (localKey != null ? localKey.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
@@ -27,11 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Journal extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.JOURNAL.getName();
     
     /** 
      * Name of journal 
@@ -58,13 +53,6 @@ public class Journal extends PassEntity {
      * published article to PMC. If so, whether it requires additional processing fee.  
      */
     private PmcParticipation pmcParticipation;
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-    
     
     /**
      * @return the name
@@ -153,7 +141,6 @@ public class Journal extends PassEntity {
 
         Journal that = (Journal) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (issns != null ? !issns.equals(that.issns) : that.issns != null) return false;
         if (publisher != null ? !publisher.equals(that.publisher) : that.publisher != null) return false;
@@ -166,7 +153,6 @@ public class Journal extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (issns != null ? issns.hashCode() : 0);
         result = 31 * result + (publisher != null ? publisher.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
@@ -31,7 +31,6 @@ public class Journal extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.JOURNAL.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Journal.java
@@ -19,8 +19,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Describes a Journal and the path of it's participation in PubMedCentral
  * @author Karen Hanson

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -46,7 +47,6 @@ public abstract class PassEntity {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("@context")
     protected String context = null;
-    
 
     /**
      * Retrieves the unique URI representing the resource.  
@@ -66,13 +66,6 @@ public abstract class PassEntity {
     public void setId(URI id) {
         this.id = id;
     }
-
-    /**
-     * Returns the entity type as String. This is used in JSON to identify the object type.
-     * The type string becomes a "@type:" property when converted to JSON.
-     * @return the type
-     */
-    public abstract String getType();
 
     /**
      * @return the context

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
@@ -17,7 +17,6 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * Abstract method that all PASS model entities inherit from. All entities can include 
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 public abstract class PassEntity {
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
@@ -32,7 +32,6 @@ public class Policy extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.POLICY.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
@@ -20,8 +20,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Describes a Policy. Policies determine the rules that need to be followed by a Submission.
  * @author Karen Hanson

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
@@ -28,11 +28,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Policy extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.POLICY.getName();
     
     /** 
      * Title of policy e.g. "NIH Public Access Policy" 
@@ -64,13 +59,6 @@ public class Policy extends PassEntity {
      */
     private URI funder;
 
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-    
-    
     /**
      * @return the title
      */
@@ -175,7 +163,6 @@ public class Policy extends PassEntity {
 
         Policy that = (Policy) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (title != null ? !title.equals(that.title) : that.title != null) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (policyUrl != null ? !policyUrl.equals(that.policyUrl) : that.policyUrl != null) return false;
@@ -189,7 +176,6 @@ public class Policy extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (policyUrl != null ? policyUrl.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Publication.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Publication.java
@@ -27,11 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Publication extends PassEntity {
 
     /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.PUBLICATION.getName();
-
-    /** 
      * Title of publication 
      */
     private String title;
@@ -66,11 +61,6 @@ public class Publication extends PassEntity {
      * Issue of journal that contains the publication (if article) 
      */
     private String issue;
-    
-    @Override
-    public String getType() {
-        return type;
-    }
         
     /**
      * @return the title
@@ -192,7 +182,6 @@ public class Publication extends PassEntity {
 
         Publication that = (Publication) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (title != null ? !title.equals(that.title) : that.title != null) return false;
         if (publicationAbstract != null ? !publicationAbstract.equals(that.publicationAbstract) : that.publicationAbstract != null) return false;
         if (doi != null ? !doi.equals(that.doi) : that.doi != null) return false;
@@ -207,7 +196,6 @@ public class Publication extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + (publicationAbstract != null ? publicationAbstract.hashCode() : 0);
         result = 31 * result + (doi != null ? doi.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Publication.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Publication.java
@@ -29,7 +29,6 @@ public class Publication extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.PUBLICATION.getName();
 
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
@@ -15,8 +15,6 @@
  */
 package org.dataconservancy.pass.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Describes a Publisher and its related Journals, also the path of it's participation in PubMedCentral
  * @author Karen Hanson

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
@@ -23,11 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Publisher extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.PUBLISHER.getName();
     
     /** 
      * Name of publisher 
@@ -39,12 +34,6 @@ public class Publisher extends PassEntity {
      * published article to PMC. If so, whether it requires additional processing fee.  
      */
     private PmcParticipation pmcParticipation;
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
         
     /**
      * @return the name
@@ -86,7 +75,6 @@ public class Publisher extends PassEntity {
 
         Publisher that = (Publisher) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (pmcParticipation != null ? !pmcParticipation.equals(that.pmcParticipation) : that.pmcParticipation != null) return false;
         return true;
@@ -96,7 +84,6 @@ public class Publisher extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (pmcParticipation != null ? pmcParticipation.hashCode() : 0);
         return result;

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Publisher.java
@@ -27,7 +27,6 @@ public class Publisher extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.PUBLISHER.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
@@ -17,8 +17,6 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Describes a Repository. A Repository is the target of a Deposit.
  * @author Karen Hanson

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
@@ -25,11 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Repository extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.REPOSITORY.getName();
     
     /** 
      * Name of repository e.g. "PubMed Central" 
@@ -50,13 +45,6 @@ public class Repository extends PassEntity {
      * Stringified JSON representing a form template to be loaded by the front-end when this Repository is selected
      */
     private String formSchema;
-
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
 
     
     /**
@@ -131,7 +119,6 @@ public class Repository extends PassEntity {
 
         Repository that = (Repository) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (url != null ? !url.equals(that.url) : that.url != null) return false;
@@ -143,7 +130,6 @@ public class Repository extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (url != null ? url.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
@@ -29,7 +29,6 @@ public class Repository extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.REPOSITORY.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/RepositoryCopy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/RepositoryCopy.java
@@ -30,11 +30,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class RepositoryCopy extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.REPOSITORY_COPY.getName();
     
     /** 
      * IDs assigned by the repository 
@@ -111,13 +106,6 @@ public class RepositoryCopy extends PassEntity {
         }
         
     }
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-
     
     /**
      * @return the externalIds
@@ -207,7 +195,6 @@ public class RepositoryCopy extends PassEntity {
 
         RepositoryCopy that = (RepositoryCopy) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (externalIds != null ? !externalIds.equals(that.externalIds) : that.externalIds != null) return false;
         if (copyStatus != null ? !copyStatus.equals(that.copyStatus) : that.copyStatus != null) return false;
         if (accessUrl != null ? !accessUrl.equals(that.accessUrl) : that.accessUrl != null) return false;
@@ -220,7 +207,6 @@ public class RepositoryCopy extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (externalIds != null ? externalIds.hashCode() : 0);
         result = 31 * result + (copyStatus != null ? copyStatus.hashCode() : 0);
         result = 31 * result + (accessUrl != null ? accessUrl.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/RepositoryCopy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/RepositoryCopy.java
@@ -34,7 +34,6 @@ public class RepositoryCopy extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.REPOSITORY_COPY.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
@@ -40,7 +40,6 @@ public class Submission extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.SUBMISSION.getName();
 
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
@@ -38,11 +38,6 @@ import org.joda.time.DateTime;
 public class Submission extends PassEntity {
 
     /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.SUBMISSION.getName();
-
-    /** 
      * Stringified JSON representation of metadata captured by the relevant repository forms
      */
     private String metadata;
@@ -159,13 +154,6 @@ public class Submission extends PassEntity {
             return this.value;
         }
     }
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-
     
     /**
     * @return the metadata
@@ -319,7 +307,6 @@ public class Submission extends PassEntity {
 
         Submission that = (Submission) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
         if (source != null ? !source.equals(that.source) : that.source != null) return false;
         if (submitted != null ? !submitted.equals(that.submitted) : that.submitted != null) return false;
@@ -336,7 +323,6 @@ public class Submission extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
         result = 31 * result + (source != null ? source.hashCode() : 0);
         result = 31 * result + (submitted != null ? submitted.hashCode() : 0);

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
@@ -32,7 +32,6 @@ public class User extends PassEntity {
     /** 
      * String type name, specifically used to set "@type" in JSON serialization
      */
-    @JsonProperty("@type")
     private String type = PassEntityType.USER.getName();
     
     /** 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
@@ -28,11 +28,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class User extends PassEntity {
-
-    /** 
-     * String type name, specifically used to set "@type" in JSON serialization
-     */
-    private String type = PassEntityType.USER.getName();
     
     /** 
      * Unique login name used by user 
@@ -125,13 +120,6 @@ public class User extends PassEntity {
             return this.value;
         }
     }
-
-    
-    @Override
-    public String getType() {
-        return type;
-    }
-
     
     /**
      * @return the username
@@ -316,7 +304,6 @@ public class User extends PassEntity {
 
         User that = (User) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (username != null ? !username.equals(that.username) : that.username != null) return false;
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
         if (middleName != null ? !middleName.equals(that.middleName) : that.middleName != null) return false;
@@ -335,7 +322,6 @@ public class User extends PassEntity {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
         result = 31 * result + (middleName != null ? middleName.hashCode() : 0);

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/ContributorModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/ContributorModelTests.java
@@ -47,7 +47,6 @@ public class ContributorModelTests {
         Contributor contributor = objectMapper.readValue(json, Contributor.class);
         
         assertEquals(TestValues.CONTRIBUTOR_ID_1, contributor.getId().toString());
-        assertEquals("Contributor", contributor.getType());
         assertEquals(TestValues.USER_FIRST_NAME, contributor.getFirstName());
         assertEquals(TestValues.USER_MIDDLE_NAME, contributor.getMiddleName());
         assertEquals(TestValues.USER_LAST_NAME, contributor.getLastName());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/DepositModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/DepositModelTests.java
@@ -48,7 +48,6 @@ public class DepositModelTests {
         Deposit deposit = objectMapper.readValue(json, Deposit.class);
         
         assertEquals(TestValues.DEPOSIT_ID_1, deposit.getId().toString());
-        assertEquals("Deposit", deposit.getType());
         assertEquals(DepositStatus.of(TestValues.DEPOSIT_STATUS), deposit.getDepositStatus());
         assertEquals(TestValues.DEPOSIT_STATUSREF, deposit.getDepositStatusRef());
         assertEquals(TestValues.SUBMISSION_ID_1, deposit.getSubmission().toString());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/FileModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/FileModelTests.java
@@ -48,7 +48,6 @@ public class FileModelTests {
         File file = objectMapper.readValue(json, File.class);
         
         assertEquals(TestValues.FILE_ID_1, file.getId().toString());
-        assertEquals("File", file.getType());
         assertEquals(TestValues.FILE_NAME, file.getName());
         assertEquals(TestValues.FILE_URI, file.getUri().toString());
         assertEquals(TestValues.FILE_DESCRIPTION, file.getDescription());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/FunderModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/FunderModelTests.java
@@ -47,7 +47,6 @@ public class FunderModelTests {
         Funder funder = objectMapper.readValue(json, Funder.class);
         
         assertEquals(TestValues.FUNDER_ID_1, funder.getId().toString());
-        assertEquals("Funder", funder.getType());
         assertEquals(TestValues.FUNDER_NAME, funder.getName());
         assertEquals(TestValues.FUNDER_URL, funder.getUrl().toString());
         assertEquals(TestValues.POLICY_ID_1, funder.getPolicy().toString());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/GrantModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/GrantModelTests.java
@@ -55,7 +55,6 @@ public class GrantModelTests {
         Grant grant = objectMapper.readValue(json, Grant.class);
         
         assertEquals(TestValues.GRANT_ID_1, grant.getId().toString());
-        assertEquals("Grant", grant.getType());
         assertEquals(TestValues.GRANT_AWARD_NUMBER, grant.getAwardNumber());
         assertEquals(TestValues.GRANT_STATUS, grant.getAwardStatus().toString());
         assertEquals(TestValues.GRANT_LOCALKEY, grant.getLocalKey());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/JournalModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/JournalModelTests.java
@@ -50,7 +50,6 @@ public class JournalModelTests {
         Journal journal = objectMapper.readValue(json, Journal.class);
         
         assertEquals(TestValues.JOURNAL_ID_1, journal.getId().toString());
-        assertEquals("Journal", journal.getType());
         assertEquals(TestValues.JOURNAL_NAME, journal.getName());
         assertEquals(TestValues.JOURNAL_ISSN_1, journal.getIssns().get(0));
         assertEquals(TestValues.JOURNAL_ISSN_2, journal.getIssns().get(1));

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/PolicyModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/PolicyModelTests.java
@@ -50,7 +50,6 @@ public class PolicyModelTests {
         Policy policy = objectMapper.readValue(json, Policy.class);
         
         assertEquals(TestValues.POLICY_ID_1, policy.getId().toString());
-        assertEquals("Policy", policy.getType());
         assertEquals(TestValues.POLICY_TITLE, policy.getTitle());
         assertEquals(TestValues.POLICY_DESCRIPTION, policy.getDescription());
         assertEquals(TestValues.REPOSITORY_ID_1, policy.getRepositories().get(0).toString());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/PublicationModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/PublicationModelTests.java
@@ -48,7 +48,6 @@ public class PublicationModelTests {
         Publication publication = objectMapper.readValue(json, Publication.class);
         
         assertEquals(TestValues.PUBLICATION_ID_1, publication.getId().toString());
-        assertEquals("Publication", publication.getType());
         assertEquals(TestValues.PUBLICATION_TITLE, publication.getTitle());
         assertEquals(TestValues.PUBLICATION_ABSTRACT, publication.getPublicationAbstract());
         assertEquals(TestValues.PUBLICATION_DOI, publication.getDoi());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/PublisherModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/PublisherModelTests.java
@@ -47,7 +47,6 @@ public class PublisherModelTests {
         Publisher publisher = objectMapper.readValue(json, Publisher.class);
         
         assertEquals(TestValues.PUBLISHER_ID_1, publisher.getId().toString());
-        assertEquals("Publisher", publisher.getType());
         assertEquals(TestValues.PUBLISHER_NAME, publisher.getName());
         assertEquals(TestValues.PUBLISHER_PMCPARTICIPATION, publisher.getPmcParticipation().name());
     }

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryCopyModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryCopyModelTests.java
@@ -51,7 +51,6 @@ public class RepositoryCopyModelTests {
         RepositoryCopy repositoryCopy = objectMapper.readValue(json, RepositoryCopy.class);
         
         assertEquals(TestValues.REPOSITORYCOPY_ID_1, repositoryCopy.getId().toString());
-        assertEquals("RepositoryCopy", repositoryCopy.getType());
         assertEquals(CopyStatus.of(TestValues.REPOSITORYCOPY_STATUS), repositoryCopy.getCopyStatus());
         assertEquals(TestValues.REPOSITORYCOPY_EXTERNALID_1, repositoryCopy.getExternalIds().get(0));
         assertEquals(TestValues.REPOSITORYCOPY_EXTERNALID_2, repositoryCopy.getExternalIds().get(1));

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
@@ -47,7 +47,6 @@ public class RepositoryModelTests {
         Repository repository = objectMapper.readValue(json, Repository.class);
         
         assertEquals(TestValues.REPOSITORY_ID_1, repository.getId().toString());
-        assertEquals("Repository", repository.getType());
         assertEquals(TestValues.REPOSITORY_NAME, repository.getName());
         assertEquals(TestValues.REPOSITORY_DESCRIPTION, repository.getDescription());
         assertEquals(TestValues.REPOSITORY_URL, repository.getUrl().toString());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
@@ -56,7 +56,6 @@ public class SubmissionModelTests {
         Submission submission = objectMapper.readValue(json, Submission.class);
         
         assertEquals(TestValues.SUBMISSION_ID_1, submission.getId().toString());
-        assertEquals("Submission", submission.getType());
         assertEquals(TestValues.SUBMISSION_METADATA, submission.getMetadata());
         assertEquals(TestValues.SUBMISSION_SUBMITTED, submission.getSubmitted());
         assertEquals(TestValues.SUBMISSION_STATUS, submission.getAggregatedDepositStatus().toString());

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/UserModelTest.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/UserModelTest.java
@@ -51,7 +51,6 @@ public class UserModelTest {
         User user = objectMapper.readValue(json, User.class);
         
         assertEquals(TestValues.USER_ID_1, user.getId().toString());
-        assertEquals("User", user.getType());
         assertEquals(TestValues.USER_NAME, user.getUsername());
         assertEquals(TestValues.USER_ROLE_1, user.getRoles().get(0).toString());
         assertEquals(TestValues.USER_ROLE_2, user.getRoles().get(1).toString());

--- a/pass-test-data/src/main/resources/contributor.json
+++ b/pass-test-data/src/main/resources/contributor.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/contributors/1",
+	"@type": "Contributor",
 	"firstName": "June",
 	"middleName": "Marie",
 	"lastName": "Smith",

--- a/pass-test-data/src/main/resources/deposit.json
+++ b/pass-test-data/src/main/resources/deposit.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/deposits/1",
+	"@type": "Deposit",
 	"depositStatus": "submitted",
 	"depositStatusRef": "http://depositstatusref.example/abc",
 	"submission": "https://example.org/fedora/submissions/1",

--- a/pass-test-data/src/main/resources/file.json
+++ b/pass-test-data/src/main/resources/file.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/files/1",
+	"@type": "File",
 	"name": "article.pdf",
 	"uri": "https://someplace.dl/a/b/c/article.pdf",
 	"description": "The file is an article",

--- a/pass-test-data/src/main/resources/funder.json
+++ b/pass-test-data/src/main/resources/funder.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/funders/1",
+	"@type": "Funder",
 	"name": "Funder A",
 	"url": "https://nih.gov",
 	"policy": "https://example.org/fedora/policies/1",

--- a/pass-test-data/src/main/resources/grant.json
+++ b/pass-test-data/src/main/resources/grant.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/grants/1",
+	"@type": "Grant",
 	"awardNumber": "RH1234CDE",
 	"awardStatus": "active",
 	"localKey": "ABC123",

--- a/pass-test-data/src/main/resources/journal.json
+++ b/pass-test-data/src/main/resources/journal.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/journals/1",
+	"@type": "Journal",
 	"name": "Test Journal",
 	"issns": ["1234-5678","5678-1234"],
 	"publisher": "https://example.org/fedora/publishers/1",

--- a/pass-test-data/src/main/resources/policy.json
+++ b/pass-test-data/src/main/resources/policy.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/policies/1",
+	"@type": "Policy",
 	"title": "Policy A",
 	"description": "You must submit to any OA repo",
 	"policyUrl": "https://somefunder.org/policy",

--- a/pass-test-data/src/main/resources/publication.json
+++ b/pass-test-data/src/main/resources/publication.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/publications/1",
+	"@type": "Publication",
 	"title": "Some article",
 	"abstract": "An article about something",
 	"doi": "10.0101/1234abcd",

--- a/pass-test-data/src/main/resources/publisher.json
+++ b/pass-test-data/src/main/resources/publisher.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/publishers/1",
+	"@type": "Publisher",
 	"name": "Publisher A",
 	"pmcParticipation": "A"
 }

--- a/pass-test-data/src/main/resources/repository.json
+++ b/pass-test-data/src/main/resources/repository.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/repositories/1",
+	"@type": "Repository",
 	"name": "Repository A",
 	"description": "An OA repository run by funder A",
 	"url": "https://repo-example.org/",

--- a/pass-test-data/src/main/resources/repositorycopy.json
+++ b/pass-test-data/src/main/resources/repositorycopy.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/repositoryCopies/1",
+	"@type": "RepositoryCopy",
 	"externalIds": ["PMC12345","NIHMS1234"],
 	"copyStatus": "accepted",
 	"accessUrl": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12345/",

--- a/pass-test-data/src/main/resources/submission.json
+++ b/pass-test-data/src/main/resources/submission.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/submissions/1",
+	"@type": "Submission",
 	"aggregatedDepositStatus": "in-progress",
 	"publication": "https://example.org/fedora/publications/1",
 	"user": "https://example.org/fedora/users/1",

--- a/pass-test-data/src/main/resources/user.json
+++ b/pass-test-data/src/main/resources/user.json
@@ -1,5 +1,6 @@
 {
 	"@id": "https://example.org/fedora/users/1",
+	"@type": "User",
 	"username": "am12345",
 	"firstName": "June",
 	"middleName": "Marie",


### PR DESCRIPTION
Implements `Map<String, Collection<URI>> getIncoming(URI passEntity)` for the `PassClient` interface.

Updates Jackson type handling so that exceptions are thrown when `readResource(URI, Class<? extends PassEntity>)` retrieves a resource of a type that differs from the supplied type.  

*  The `@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)` annotation is added to the `PassEntity` class, and `@JsonProperty("@type")` annotations were _removed_ from sub classes.  
*  Test JSON resources were updated to carry an `"@type": "Type"` property.
*  `type` member variable of PASS model classes was removed
*  The Fedora crud client is updated to use `Class.simpleName()` when looking up the pluralized container name for creating resources.