### PR TITLE
Consolidate test cleanup code, add trailing forward-slash to Fedora baseUrl if missing

### DIFF
--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -112,7 +112,7 @@
                   <PI_FEDORA_JMS_BROKER>tcp://${FCREPO_HOST}:${FCREPO_JMS_PORT}</PI_FEDORA_JMS_BROKER>
                   <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
                   <PI_TYPE_PREFIX>http://example.org/pass/</PI_TYPE_PREFIX>
-                  <PI_LOG_LEVEL>debug</PI_LOG_LEVEL>
+                  <PI_LOG_LEVEL>DEBUG</PI_LOG_LEVEL>
                 </env>
                 <links>
                   <link>fcrepo:localhost</link>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
+              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateFindByRoundTripIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateFindByRoundTripIT.java
@@ -67,6 +67,7 @@ public class CreateFindByRoundTripIT extends ClientITBase {
                 URI uri = client.findByAttribute(forDeposit.getClass(), "@id", entityUri);   
                 assertEquals(entityUri, uri);
             });
+            createdUris.put(entityUri, forDeposit.getClass());
 
             for (final PropertyDescriptor pd : Introspector.getBeanInfo(forDeposit.getClass(), PassEntity.class).getPropertyDescriptors()) {
                 Method m = pd.getReadMethod();
@@ -90,10 +91,6 @@ public class CreateFindByRoundTripIT extends ClientITBase {
             } 
         } catch (Exception ex) {
             throw new RuntimeException("Round trip check of indexer failed", ex);
-        } finally {
-            if (entityUri!=null) {
-                client.deleteResource(entityUri);
-            }
         }
         
     }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateReadResourceRoundTripIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateReadResourceRoundTripIT.java
@@ -68,14 +68,9 @@ public class CreateReadResourceRoundTripIT extends ClientITBase {
 
     void roundTrip(PassEntity asDeposited) {
         final URI entityUri = client.createResource(asDeposited);   
-        try {
-            final PassEntity retrieved = client.readResource(entityUri, asDeposited.getClass());
-            assertReflectionEquals(normalized(asDeposited), normalized(retrieved),
-                                   ReflectionComparatorMode.LENIENT_ORDER);
-        } finally {
-            if (entityUri!=null) {
-                client.deleteResource(entityUri);
-            }
-        }
+        final PassEntity retrieved = client.readResource(entityUri, asDeposited.getClass());
+        assertReflectionEquals(normalized(asDeposited), normalized(retrieved),
+                               ReflectionComparatorMode.LENIENT_ORDER);
+        createdUris.put(entityUri, asDeposited.getClass());
     }
 }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
@@ -51,52 +51,40 @@ public class FindAllByAttributeIT extends ClientITBase {
         user.setDisplayName("Mary \"The Shark\" Schäfer");
         user.setAffiliation("Lamar & Schäfer Laboratory, Nürnberg");
         URI userId1 = client.createResource(user);
+        createdUris.put(userId1, User.class);  
         URI userId2 = client.createResource(user);
-        try {
-            //make sure records are in the indexer before continuing
-            attempt(RETRIES, () -> {
-                final URI uri = client.findByAttribute(User.class, "@id", userId1);
-                assertEquals(userId1, uri);
-            });        
-            attempt(RETRIES, () -> {
-                final URI uri = client.findByAttribute(User.class, "@id", userId2);
-                assertEquals(userId2, uri);
-            });        
-            
-    
-            Set<URI> uris = client.findAllByAttribute(User.class, "firstName", user.getFirstName());
-            assertEquals(2, uris.size());
-            assertTrue(uris.contains(userId1));
-            assertTrue(uris.contains(userId2));
-    
-            uris = client.findAllByAttribute(User.class, "lastName", user.getLastName());
-            assertEquals(2, uris.size());
-            assertTrue(uris.contains(userId1));
-            assertTrue(uris.contains(userId2));
-            
-            uris = client.findAllByAttribute(User.class, "displayName", user.getDisplayName());
-            assertEquals(2, uris.size());
-            assertTrue(uris.contains(userId1));
-            assertTrue(uris.contains(userId2));
-            
-            uris = client.findAllByAttribute(User.class, "affiliation", user.getAffiliation());
-            assertEquals(2, uris.size());
-            assertTrue(uris.contains(userId1));
-            assertTrue(uris.contains(userId2));
-            
-        } finally {
-            //need to log fail if this doesn't work as it could mess up re-testing if data isn't cleaned out
-            try {
-                if (userId1 != null) {
-                    client.deleteResource(userId1);
-                }
-                if (userId2 != null) {
-                    client.deleteResource(userId2);
-                }
-            } catch (Exception ex) {
-                fail("Could not clean up from FindAllByAttributeIT.testSpecialCharacterSearch(), this may cause errors if test is rerun on the same dbs");
-            }
-        }
+        createdUris.put(userId2, User.class);  
+
+        //make sure records are in the indexer before continuing
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(User.class, "@id", userId1);
+            assertEquals(userId1, uri);
+        });      
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(User.class, "@id", userId2);
+            assertEquals(userId2, uri);
+        });        
+        
+
+        Set<URI> uris = client.findAllByAttribute(User.class, "firstName", user.getFirstName());
+        assertEquals(2, uris.size());
+        assertTrue(uris.contains(userId1));
+        assertTrue(uris.contains(userId2));
+
+        uris = client.findAllByAttribute(User.class, "lastName", user.getLastName());
+        assertEquals(2, uris.size());
+        assertTrue(uris.contains(userId1));
+        assertTrue(uris.contains(userId2));
+        
+        uris = client.findAllByAttribute(User.class, "displayName", user.getDisplayName());
+        assertEquals(2, uris.size());
+        assertTrue(uris.contains(userId1));
+        assertTrue(uris.contains(userId2));
+        
+        uris = client.findAllByAttribute(User.class, "affiliation", user.getAffiliation());
+        assertEquals(2, uris.size());
+        assertTrue(uris.contains(userId1));
+        assertTrue(uris.contains(userId2));
         
     }
     
@@ -108,33 +96,29 @@ public class FindAllByAttributeIT extends ClientITBase {
     public void testLimitAndOffset() throws Exception {
         String descrip = "short fake description";
         String descripFld = "description";
-        try {
-            URI uri = null;
-            for(int i = 0; i < 10; i++){
-                File file = random(File.class, 2);
-                file.setDescription(descrip);
-                uri = client.createResource(file);
-            }
-            
-            final URI searchUri = uri;
-            
-            attempt(RETRIES, () -> { //make sure last one is in the index
-                final URI matchedUri = client.findByAttribute(File.class, "@id", searchUri);
-                assertEquals(searchUri, matchedUri);
-            }); 
-    
-            Set<URI> matches = client.findAllByAttribute(File.class, descripFld, descrip, 4, 0);
-            assertEquals(4, matches.size());
-            matches = client.findAllByAttribute(File.class, descripFld, descrip, 4, 0);
-            assertEquals(4, matches.size());
-            matches = client.findAllByAttribute(File.class, descripFld, descrip, 2, 0);
-            assertEquals(2, matches.size());       
-        } finally {
-            Set <URI> matches = client.findAllByAttribute(File.class, descripFld, descrip);
-            for (URI match : matches) {
-                client.deleteResource(match);
-            }
+
+        URI uri = null;
+        for(int i = 0; i < 10; i++){
+            File file = random(File.class, 2);
+            file.setDescription(descrip);
+            uri = client.createResource(file);
+            createdUris.put(uri, File.class);  
         }
+        
+        final URI searchUri = uri;
+        
+        attempt(RETRIES, () -> { //make sure last one is in the index
+            final URI matchedUri = client.findByAttribute(File.class, "@id", searchUri);
+            assertEquals(searchUri, matchedUri);
+        }); 
+
+        Set<URI> matches = client.findAllByAttribute(File.class, descripFld, descrip, 4, 0);
+        assertEquals(4, matches.size());
+        matches = client.findAllByAttribute(File.class, descripFld, descrip, 4, 0);
+        assertEquals(4, matches.size());
+        matches = client.findAllByAttribute(File.class, descripFld, descrip, 2, 0);
+        assertEquals(2, matches.size());   
+            
     }    
     
     /**
@@ -144,19 +128,16 @@ public class FindAllByAttributeIT extends ClientITBase {
     public void testNoMatchFound() {
         Grant grant = random(Grant.class, 1);
         URI grantId = client.createResource(grant); //create something so it's not empty index
+        createdUris.put(grantId, Grant.class);  
         
-        try {
-            attempt(RETRIES, () -> {
-                final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
-                assertEquals(grantId, uri);
-            });        
-            
-            Set<URI> matchedIds = client.findAllByAttribute(Grant.class, "awardNumber", "no match");
-            assertNotNull(matchedIds);
-            assertEquals(0, matchedIds.size());
-        } finally {
-            client.deleteResource(grantId);
-        }
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
+            assertEquals(grantId, uri);
+        });        
+        
+        Set<URI> matchedIds = client.findAllByAttribute(Grant.class, "awardNumber", "no match");
+        assertNotNull(matchedIds);
+        assertEquals(0, matchedIds.size());
     }
 
     @Test
@@ -164,24 +145,19 @@ public class FindAllByAttributeIT extends ClientITBase {
         Deposit deposit = random(Deposit.class, 1);
         deposit.setDepositStatus(null);
         URI expectedUri = client.createResource(deposit);
+        createdUris.put(expectedUri, Deposit.class);  
 
-        try {
-            attempt(RETRIES, () -> {
-                assertEquals(expectedUri.getPath(),
-                        client.findByAttribute(Deposit.class, "@id", expectedUri).getPath());
-            });
-
+        attempt(RETRIES, () -> {
             assertEquals(expectedUri.getPath(),
-                    client.findByAttribute(Deposit.class, "depositStatus", null).getPath());
-            Set<URI> deposits = client.findAllByAttribute(Deposit.class, "depositStatus", null);
-            assertEquals(1, deposits.size());
-            assertEquals(expectedUri.getPath(), deposits.iterator().next().getPath());
-        } finally {
-            Set <URI> matches = client.findAllByAttribute(Deposit.class, "depositStatus", null);
-            for (URI match : matches) {
-                client.deleteResource(match);
-            }
-        }
+                    client.findByAttribute(Deposit.class, "@id", expectedUri).getPath());
+        });
+
+        assertEquals(expectedUri.getPath(),
+                client.findByAttribute(Deposit.class, "depositStatus", null).getPath());
+        Set<URI> deposits = client.findAllByAttribute(Deposit.class, "depositStatus", null);
+        assertEquals(1, deposits.size());
+        assertEquals(expectedUri.getPath(), deposits.iterator().next().getPath());
+
     }
 
     /**

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
@@ -51,25 +51,22 @@ public class FindByAttributeIT extends ClientITBase {
 
         Grant grant = random(Grant.class, 1);
         final URI grantId = client.createResource(grant);
+        createdUris.put(grantId, Grant.class);
 
-        try {
-            attempt(RETRIES, () -> { // check the record exists before continuing
-                final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
-                assertEquals(grantId, uri);
-            });
-    
-            URI foundGrantId1 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber());
-            assertEquals(grantId, foundGrantId1);
-    
-            URI foundGrantId2 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber().toLowerCase());
-            assertEquals(grantId, foundGrantId2);
-            
-            URI foundGrantId3 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber().toUpperCase());
-            assertEquals(grantId, foundGrantId3);
-        } finally {
-            client.deleteResource(grantId);
-        }
+        attempt(RETRIES, () -> { // check the record exists before continuing
+            final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
+            assertEquals(grantId, uri);
+        });
 
+        URI foundGrantId1 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber());
+        assertEquals(grantId, foundGrantId1);
+
+        URI foundGrantId2 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber().toLowerCase());
+        assertEquals(grantId, foundGrantId2);
+        
+        URI foundGrantId3 = client.findByAttribute(Grant.class, "awardNumber", grant.getAwardNumber().toUpperCase());
+        assertEquals(grantId, foundGrantId3);
+        
     }
     
     /**
@@ -85,34 +82,24 @@ public class FindByAttributeIT extends ClientITBase {
         user.setDisplayName("Mary \"The Shark\" Schäfer");
         user.setAffiliation("Lamar & Schäfer Laboratory, Nürnberg");
         URI userId = client.createResource(user);
-        try {
-            attempt(RETRIES, () -> { // check the record exists
-                final URI uri = client.findByAttribute(User.class, "@id", userId);
-                assertEquals(userId, uri);
-            });        
-            
-            URI uri1 = client.findByAttribute(User.class, "firstName", user.getFirstName());
-            assertEquals(userId, uri1);
-    
-            URI uri2 = client.findByAttribute(User.class, "lastName", user.getLastName());
-            assertEquals(userId, uri2);
-            
-            URI uri3 = client.findByAttribute(User.class, "displayName", user.getDisplayName());
-            assertEquals(userId, uri3);
-    
-            URI uri4 = client.findByAttribute(User.class, "affiliation", user.getAffiliation());
-            assertEquals(userId, uri4);
-            
-        } finally {
-            //need to log fail if this doesn't work as it could mess up re-testing if data isn't cleaned out
-            try {
-                if (userId != null) {
-                    client.deleteResource(userId);
-                }
-            } catch (Exception ex) {
-                fail("Could not clean up from FindByAttributeIT.testSpecialCharacterSearch(), this may cause errors if test is rerun on the same dbs");
-            }
-        }
+        createdUris.put(userId, User.class);
+        
+        attempt(RETRIES, () -> { // check the record exists
+            final URI uri = client.findByAttribute(User.class, "@id", userId);
+            assertEquals(userId, uri);
+        });        
+        
+        URI uri1 = client.findByAttribute(User.class, "firstName", user.getFirstName());
+        assertEquals(userId, uri1);
+
+        URI uri2 = client.findByAttribute(User.class, "lastName", user.getLastName());
+        assertEquals(userId, uri2);
+        
+        URI uri3 = client.findByAttribute(User.class, "displayName", user.getDisplayName());
+        assertEquals(userId, uri3);
+
+        URI uri4 = client.findByAttribute(User.class, "affiliation", user.getAffiliation());
+        assertEquals(userId, uri4);
         
     }
     
@@ -123,18 +110,16 @@ public class FindByAttributeIT extends ClientITBase {
     public void testNoMatchFound() {
         Grant grant = random(Grant.class, 1);
         final URI grantId = client.createResource(grant); //create something so it's not empty
-        try {
-            attempt(RETRIES, () -> {
-                final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
-                assertEquals(grantId, uri);
-            }); 
-            
-            URI matchedId = client.findByAttribute(Grant.class, "awardNumber", "no match");
-            assertEquals(null, matchedId);
-            
-        } finally {
-            client.deleteResource(grantId);
-        }
+        createdUris.put(grantId, Grant.class);
+        
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(Grant.class, "@id", grantId);
+            assertEquals(grantId, uri);
+        }); 
+        
+        URI matchedId = client.findByAttribute(Grant.class, "awardNumber", "no match");
+        assertEquals(null, matchedId);
+        
     }
     
     /**
@@ -145,21 +130,19 @@ public class FindByAttributeIT extends ClientITBase {
     public void testMultiRowArraySearch() {
         Submission submission = random(Submission.class, 2); //create random submission where each list has 2 rows
         final URI submissionId = client.createResource(submission);
-        try {
-            attempt(RETRIES, () -> {
-                final URI uri = client.findByAttribute(Submission.class, "@id", submissionId);
-                assertEquals(submissionId, uri);
-            }); 
-            
-            URI foundId1 = client.findByAttribute(Submission.class, "repositories", submission.getRepositories().get(0));
-            URI foundId2 = client.findByAttribute(Submission.class, "repositories", submission.getRepositories().get(1));
-            
-            assertEquals(submissionId, foundId1);
-            assertEquals(submissionId, foundId2);
-            
-        } finally {
-            client.deleteResource(submissionId);
-        }
+        createdUris.put(submissionId, Submission.class);
+
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(Submission.class, "@id", submissionId);
+            assertEquals(submissionId, uri);
+        }); 
+        
+        URI foundId1 = client.findByAttribute(Submission.class, "repositories", submission.getRepositories().get(0));
+        URI foundId2 = client.findByAttribute(Submission.class, "repositories", submission.getRepositories().get(1));
+        
+        assertEquals(submissionId, foundId1);
+        assertEquals(submissionId, foundId2);
+
     }
     
     /**

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/IncomingLinksIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/IncomingLinksIT.java
@@ -19,7 +19,6 @@ import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.File;
 import org.dataconservancy.pass.model.Submission;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -64,37 +63,34 @@ public class IncomingLinksIT extends ClientITBase {
         submission = new Submission();
         submission.setSource(Submission.Source.PASS);
         submission = client.readResource(client.createResource(submission), Submission.class);
+        createdUris.put(submission.getId(), Submission.class);
 
         submissionNoIncoming = new Submission();
         submissionNoIncoming.setSource(Submission.Source.PASS);
         submissionNoIncoming = client.readResource(client.createResource(submissionNoIncoming), Submission.class);
+        createdUris.put(submissionNoIncoming.getId(), Submission.class);
 
         // Add a File that references the Submission
         file = new File();
         file.setName("FileReferencingSubmission");
         file.setSubmission(submission.getId());
         file = client.readResource(client.createResource(file), File.class);
+        createdUris.put(file.getId(), File.class);
 
         // Add two Deposits that reference the Submission
         depositOne = new Deposit();
         depositOne.setDepositStatusRef("http://reference/to/deposit/status/1");
         depositOne.setSubmission(submission.getId());
         depositOne = client.readResource(client.createResource(depositOne), Deposit.class);
+        createdUris.put(depositOne.getId(), Deposit.class);
 
         depositTwo = new Deposit();
         depositTwo.setDepositStatusRef("http://reference/to/deposit/status/2");
         depositTwo.setSubmission(submission.getId());
         depositTwo = client.readResource(client.createResource(depositTwo), Deposit.class);
+        
+        createdUris.put(depositTwo.getId(), Deposit.class);
 
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        client.deleteResource(submission.getId());
-        client.deleteResource(submissionNoIncoming.getId());
-        client.deleteResource(file.getId());
-        client.deleteResource(depositOne.getId());
-        client.deleteResource(depositTwo.getId());
     }
 
     /**

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
@@ -16,21 +16,23 @@
 
 package org.dataconservancy.pass.client.integration;
 
-import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
-
 import java.lang.reflect.Method;
+
 import java.net.URI;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dataconservancy.pass.model.PassEntity;
-
 import org.apache.commons.beanutils.BeanUtils;
+
 import org.junit.Test;
+
+import org.dataconservancy.pass.model.PassEntity;
 import org.dataconservancy.pass.model.User;
 import org.unitils.reflectionassert.ReflectionComparatorMode;
 
 import static org.junit.Assert.assertEquals;
+import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 /**
  * Tests client update functionality
  *
@@ -96,8 +98,6 @@ public class UpdateResourceIT extends ClientITBase {
             client.deleteResource(userId);
         }
     }
-    
-    
 
     PassEntity removeRelationships(PassEntity resource) {
         try {

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
@@ -74,30 +74,33 @@ public class UpdateResourceIT extends ClientITBase {
     public void patchUpdateWithDifferentModelsTest() {        
         //create a complete user
         User user = random(User.class, 1);
-        URI userId = client.createResource(user);
+        final URI userId = client.createResource(user);
+        createdUris.put(userId, User.class);
+
+        //adding a pause for indexer to catchup
+        attempt(RETRIES, () -> {
+            final URI foundUri = client.findByAttribute(User.class, "@id", userId);
+            assertEquals(userId, foundUri);
+        });
         
-        try {
-            //update using an incomplete user
-            TestUserModel incompleteUser = new TestUserModel();
-            incompleteUser.setId(userId);
-            incompleteUser.setDisplayName("Ms Tester");
-            incompleteUser.setEmail("mtester@blahblahetc.test");
-            incompleteUser.setUsername(null);
-            client.updateResource(incompleteUser);
-            
-            //verify user still has original fields and has new field values incorporated including the null username
-            User updatedUser = client.readResource(userId, User.class);
-            assertEquals(userId, updatedUser.getId());
-            assertEquals(user.getAffiliation(), updatedUser.getAffiliation());
-            assertEquals(user.getFirstName(), updatedUser.getFirstName());
-            assertEquals(user.getLastName(), updatedUser.getLastName());
-            assertEquals(incompleteUser.getDisplayName(), updatedUser.getDisplayName());
-            assertEquals(incompleteUser.getEmail(), updatedUser.getEmail());
-            assertEquals(null, updatedUser.getUsername());
-        } finally {
-            client.deleteResource(userId);
-        }
-    }
+        //update using an incomplete user
+        org.dataconservancy.pass.client.integration.User incompleteUser = new org.dataconservancy.pass.client.integration.User();
+        incompleteUser.setId(userId);
+        incompleteUser.setDisplayName("Ms Tester");
+        incompleteUser.setEmail("mtester@blahblahetc.test");
+        incompleteUser.setUsername(null);
+        client.updateResource(incompleteUser);
+        
+        //verify user still has original fields and has new field values incorporated including the null username
+        User updatedUser = client.readResource(userId, User.class);
+        assertEquals(userId, updatedUser.getId());
+        assertEquals(user.getAffiliation(), updatedUser.getAffiliation());
+        assertEquals(user.getFirstName(), updatedUser.getFirstName());
+        assertEquals(user.getLastName(), updatedUser.getLastName());
+        assertEquals(incompleteUser.getDisplayName(), updatedUser.getDisplayName());
+        assertEquals(incompleteUser.getEmail(), updatedUser.getEmail());
+        assertEquals(null, updatedUser.getUsername());
+    }    
 
     PassEntity removeRelationships(PassEntity resource) {
         try {
@@ -118,6 +121,7 @@ public class UpdateResourceIT extends ClientITBase {
 
     void createAndUpdate(PassEntity toDeposit, PassEntity updatedContent) {
         final URI passEntityUri = client.createResource(toDeposit);
+        createdUris.put(passEntityUri, toDeposit.getClass());
 
         try {
             final PassEntity intermediate = client.readResource(passEntityUri, toDeposit.getClass());
@@ -129,9 +133,6 @@ public class UpdateResourceIT extends ClientITBase {
                                    ReflectionComparatorMode.LENIENT_ORDER);
         } catch (final Exception e) {
             throw new RuntimeException(e);
-        } finally { 
-            client.deleteResource(passEntityUri);
-        }
-
+        } 
     }
 }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/User.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/User.java
@@ -26,7 +26,7 @@ import org.dataconservancy.pass.model.PassEntityType;
  * 
  * @author Karen Hanson
  */
-public class TestUserModel extends PassEntity {
+public class User extends PassEntity {
 
     /** 
      * This will pretend it is a "User" object for testing.
@@ -110,7 +110,7 @@ public class TestUserModel extends PassEntity {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
 
-        TestUserModel that = (TestUserModel) o;
+        User that = (User) o;
 
         if (type != null ? !type.equals(that.type) : that.type != null) return false;
         if (username != null ? !username.equals(that.username) : that.username != null) return false;

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraConfig.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraConfig.java
@@ -35,7 +35,7 @@ public class FedoraConfig {
     private static final String DEFAULT_PASSWORD = "moo";
     
     private static final String BASEURL_KEY = "pass.fedora.baseurl";
-    private static final String DEFAULT_BASE_URL = "http://localhost:8080/fcrepo/rest";
+    private static final String DEFAULT_BASE_URL = "http://localhost:8080/fcrepo/rest/";
 
     
     /**

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraConfig.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraConfig.java
@@ -43,6 +43,9 @@ public class FedoraConfig {
      */
     public static String getBaseUrl() {
         String baseUrl = ConfigUtil.getSystemProperty(BASEURL_KEY, DEFAULT_BASE_URL);
+        if (!baseUrl.endsWith("/")) {
+            baseUrl = baseUrl + "/";
+        }
         LOG.debug("Using baseUrl: {}", baseUrl);
         return baseUrl;
     }


### PR DESCRIPTION
This change updates the integration tests to consolidate the code for cleanup of resources after tests.  Cleanup now includes a check on the indexer to make sure the records have been removed before moving on to the next test.

Also adds missing trailing "/" on the default Fedora baseUrl