### PR TITLE
Add conflict resolution to updateResource

### DIFF
--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -42,6 +42,8 @@ public interface PassClient {
     
     /**
      * Takes any PassEntity, and updates the record matching the ID field.  
+     * Note that if you attempt to update an object that was updated between the readResource and the
+     * updateResource, an `UpdateConflictException` will be thrown.
      * @param modelObj
      * @return
      */

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
@@ -119,6 +119,7 @@ public abstract class ClientITBase {
             final PassEntity cloned = (PassEntity) BeanUtils.cloneBean(e);
             cloned.setContext("");
             cloned.setId(URI.create(""));
+            cloned.setVersionTag("");
             return cloned;
         } catch (final Exception x) {
             throw new RuntimeException(x);
@@ -154,7 +155,7 @@ public abstract class ClientITBase {
             final T entity = obj.newInstance();
 
             for (final Method m : obj.getMethods()) {
-                if (m.getName().startsWith("set") && !m.getName().equals("setId")) {
+                if (m.getName().startsWith("set") && !m.getName().equals("setId") && !m.getName().equals("setVersionTag")) {
                     final Class<?> type = m.getParameterTypes()[0];
 
                     if (String.class.isAssignableFrom(type)) {

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/UpdateConflictException.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/UpdateConflictException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.fedora;
+
+
+/**
+ * This exception is throw when attempting to update a Resource that has changed since the last 
+ * readResource from the database. When read from Fedora, each PassEntity contains an ETag 
+ * field that is verified during each update to avoid overwriting changes.
+ * 
+ * @author Karen Hanson
+ */
+public class UpdateConflictException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    
+    public UpdateConflictException() {
+        super();
+    }
+    public UpdateConflictException(String s) {
+        super(s);
+    }
+    public UpdateConflictException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+    public UpdateConflictException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntity.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,6 +40,15 @@ public abstract class PassEntity {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("@id")
     protected URI id;
+
+    /** 
+     * Version tag can be a version number or string of characters used to identify the object version
+     * This could, for example, be an HTTP ETag. Its main purpose is for comparison during updates to 
+     * ensure you do not overwrite someone else's changes. Should not be part of the JSON output
+     */
+    @JsonIgnore
+    protected String versionTag;
+    
     
     /** 
      * Optional context field, when present this can be used to convert the JSON to JSON-LD
@@ -81,6 +91,24 @@ public abstract class PassEntity {
         this.context = context;
     }
     
+    
+    /**
+     * @return the versionTag
+     */
+    public String getVersionTag() {
+        return versionTag;
+    }
+
+
+    
+    /**
+     * @param versionTag the versionTag to set
+     */
+    public void setVersionTag(String versionTag) {
+        this.versionTag = versionTag;
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
This adds ETag validation to the `updateResource` process. `versionTag` field was added to the base `PassEntity` model as a way to capture and verify object versions against the database during an update. On attempting to update an object whose versionTag (in this case the ETag) has changed, an `UpdateConflictException` is thrown.