### PR TITLE
Remove weak etag prefix from etag value

### DIFF
--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -43,7 +43,8 @@ public interface PassClient {
     /**
      * Takes any PassEntity, and updates the record matching the ID field.  
      * Note that if you attempt to update an object that was updated between the readResource and the
-     * updateResource, an `UpdateConflictException` will be thrown.
+     * updateResource, an `UpdateConflictException` will be thrown. This comparison is based on 
+     * the value in PassEntity.versionTag. Setting versionTag to null will ignore conflicts and do the update.
      * @param modelObj
      * @return
      */

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
@@ -34,6 +34,7 @@ import org.dataconservancy.pass.model.User;
 import org.unitils.reflectionassert.ReflectionComparatorMode;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 /**
  * Tests client update functionality
@@ -117,8 +118,13 @@ public class UpdateResourceIT extends ClientITBase {
         Grant grantCopy1 = client.readResource(grantId, Grant.class);
         Grant grantCopy2 = client.readResource(grantId, Grant.class);
         
-        grantCopy1.setLocalKey("123456");
-        client.updateResource(grantCopy1);
+        try {
+            grantCopy1.setLocalKey("123456");
+            client.updateResource(grantCopy1);
+        } catch (Exception ex){
+            //should not fail here!
+            fail(ex.getMessage());
+        }
         
         grantCopy2.setLocalKey("abcdefg");
         client.updateResource(grantCopy2);
@@ -148,8 +154,10 @@ public class UpdateResourceIT extends ClientITBase {
 
         try {
             final PassEntity intermediate = client.readResource(passEntityUri, toDeposit.getClass());
+            String versionTag = intermediate.getVersionTag();
             BeanUtils.copyProperties(intermediate, updatedContent);
             intermediate.setId(passEntityUri);
+            intermediate.setVersionTag(versionTag);
             client.updateResource(intermediate);
             final PassEntity asUpdated = client.readResource(passEntityUri, intermediate.getClass());
             assertReflectionEquals(normalized(updatedContent), normalized(asUpdated),

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -62,6 +62,7 @@ public class FedoraPassCrudClient {
     private final static String COMPACTED_ACCEPTTYPE = "application/ld+json";
     private final static String INCOMING_INCLUDETYPE = "http://fedora.info/definitions/v4/repository#InboundReferences";
     private final static String ETAG_HEADER = "ETag";
+    private final static String ETAG_WEAK_PREFIX = "W/";
     
     /** 
      * The Fedora client tool 
@@ -179,7 +180,14 @@ public class FedoraPassCrudClient {
 
           LOG.info("Resource read status: {}", response.getStatusCode());
           T model = adapter.toModel(response.getBody(), modelClass);
-          model.setVersionTag(response.getHeaderValue(ETAG_HEADER));
+          
+          //remove the etag prefix, not needed for version comparison
+          String etag = response.getHeaderValue(ETAG_HEADER);
+          if (etag!=null && etag.contains(ETAG_WEAK_PREFIX)) {
+              etag = etag.replace(ETAG_WEAK_PREFIX, "");
+          }
+          model.setVersionTag(etag);
+          
           return model;
           
         } catch (IOException | FcrepoOperationFailedException e) {


### PR DESCRIPTION
The "W/" before an ETag that signifies it is a "weak" ETag causes updates to fail due to mismatch. This change removes the prefix when setting `versionTag`, and also makes sure the tests catch the problem if it arises again.