### PR TITLE
Use CAPITALIZED_UNDERSCORES for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ URI grantUri = client.findByAttribute(Grant.class, "awardNumber", awardNumber);
 ```
 The Java docs provide more information about this functionality.
 
-### Environment variables
+### Configuration
+Configuration may be provided via system properties, or environment variables.  System properties are case-sensitive and separated by periods, as per Java conventions.
+Environment variables should be uppercase and separated by underscores, as per OS conventions.  For example, the fedora user may be provided by 
+a system property `-Dpass.fedora.user=myUser` or as an environment variable `PASS_FEDORA_USER=myUser`.  System properties override environment variables. 
+
 * pass.fedora.baseurl (default=http://localhost:8080/fcrepo/rest)
 * pass.fedora.user (default=admin)
 * pass.fedora.password (default=moo)

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -10,16 +10,6 @@
   <artifactId>pass-client-util</artifactId>
 
   <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
-      <artifactId>pass-model</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
     
     <dependency>
       <groupId>junit</groupId>
@@ -28,9 +18,11 @@
     </dependency>
     
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.17.2</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 </project>

--- a/pass-client-util/src/main/java/org/dataconservancy/pass/client/util/ConfigUtil.java
+++ b/pass-client-util/src/main/java/org/dataconservancy/pass/client/util/ConfigUtil.java
@@ -13,22 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.dataconservancy.pass.client.util;
 
-
 /**
- *
  * @author Karen Hanson
  */
 public class ConfigUtil {
 
-    /** 
-     * Retrieve property from environment variable or set to default
-     * @param key
+    /**
+     * Retrieve property from a system property or renvironment variable or set to default
+     * <p>
+     * Given a string as a system property name (and a default) will:
+     * <ol>
+     * <li>Look up the system property with the matching name, and return it if defined</li>
+     * <li>Try to match an environment variable matching the key transformed TO_UPPER_CASE with periods substituted
+     * with underscores</li>
+     * <li>Use the default of none others match</li>
+     * </ol>
+     * </p>
+     *
+     * @param key - property/variable name in property-normal form (period separators, ideally all lowercas)
      * @param defaultValue
      * @return
      */
     public static String getSystemProperty(final String key, final String defaultValue) {
-        return System.getProperty(key, System.getenv().getOrDefault(key, defaultValue));
+        return System.getProperty(key, System.getenv().getOrDefault(toEnvName(key), defaultValue));
+    }
+
+    static String toEnvName(String name) {
+        return name.toUpperCase().replace('.', '_');
     }
 }

--- a/pass-client-util/src/test/java/org/dataconservancy/pass/client/util/ConfigUtilTest.java
+++ b/pass-client-util/src/test/java/org/dataconservancy/pass/client/util/ConfigUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TestName;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class ConfigUtilTest {
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Rule
+    public final RestoreSystemProperties r = new RestoreSystemProperties();
+
+    @Rule
+    public final EnvironmentVariables e = new EnvironmentVariables();
+
+    @Test
+    public void getSystemPropertyTest() {
+        final String KEY = "test" + "." + testName.getMethodName();
+        final String VALUE = UUID.randomUUID().toString();
+
+        System.setProperty(KEY, VALUE);
+
+        assertEquals(VALUE, ConfigUtil.getSystemProperty(KEY, null));
+    }
+
+    @Test
+    public void getNormalizedEnvVarTest() {
+        final String KEY = "test" + "." + testName.getMethodName();
+        final String VALUE = UUID.randomUUID().toString();
+
+        /* Set the environment variable AS_UPPER_CASE_WITH_UNDERSCORES */
+        e.set(KEY.replace(".", "_").toUpperCase(), VALUE);
+
+        assertEquals(VALUE, ConfigUtil.getSystemProperty(KEY, null));
+    }
+}


### PR DESCRIPTION
Docker will only pass along environment variables if they do not have periods in them, which makes them incompatible with system property names due to conflicting naming conventions/requirements.

This updates `ConfigUtil` so that the following are equivalent when accessed via `ConfigUtil.getSystemProperty("my.prop.name")`:

* `-Dmy.prop.name=foo`
* `MY_PROP_NAME=foo`