### PR TITLE
Support POST of binary content to a repository resource.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.jpg binary

--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -15,6 +15,7 @@
  */
 package org.dataconservancy.pass.client;
 
+import java.io.InputStream;
 import java.net.URI;
 
 import java.util.Collection;
@@ -200,5 +201,31 @@ public interface PassClient {
      */
     public Map<String, Collection<URI>> getIncoming(URI passEntity);
 
-    
+    /**
+     * {@code POST}s the {@code content} to {@code entityUri}.
+     * <p>
+     * The {@code entityUri} must already exist.
+     * </p>
+     *
+     * @param entityUri a URI identifying an existing resource in the repository
+     * @param content the content to {@code POST} to the resource
+     * @return the {@code URI} used to retrieve the uploaded content
+     */
+    public URI upload(URI entityUri, InputStream content);
+
+    /**
+     * {@code POST}s the supplied {@code content} to the supplied {@code entityUri}.  Optional parameters may be
+     * supplied by the caller, and used by the implementation to, <em>e.g.</em>, supply checksums, suggest a "name" for
+     * the uploaded content.
+     * <p>
+     * The {@code entityUri} must already exist.
+     * </p>
+     *
+     * @param entityUri an existing entity in the repository
+     * @param content the content to {@code POST} to the entity
+     * @param params optional parameters to the {@code POST}, <em>i.e.</em> HTTP header values
+     * @return the {@code URI} used to retrieve the uploaded content
+     */
+    public URI upload(URI entityUri, InputStream content, Map<String, ?> params);
+
 }

--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -220,6 +220,23 @@ public interface PassClient {
      * <p>
      * The {@code entityUri} must already exist.
      * </p>
+     * <p>
+     * Supported parameters include:
+     * </p>
+     * <dl>
+     *     <dt>content-type</dt>
+     *     <dd>the mime type of the {@code content} to be {@code POST}ed; added as a {@code Content-Type} header</dd>
+     *     <dt>slug</dt>
+     *     <dd>suggested name of the resource in the repository; added as a {@code Slug} header</dd>
+     *     <dt>sha256</dt>
+     *     <dd>hexadecimal encoded SHA-256 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>sha1</dt>
+     *     <dd>hexadecimal encoded SHA-1 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>md5</dt>
+     *     <dd>hexadecimal encoded MD5 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>filename</dt>
+     *     <dd>name for {@code content}; added to a {@code Content-Disposition} header</dd>
+     * </dl>
      *
      * @param entityUri an existing entity in the repository
      * @param content the content to {@code POST} to the entity

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -241,5 +241,23 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/PostBinaryIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/PostBinaryIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.integration;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.MessageDigestCalculatingInputStream;
+import org.apache.commons.io.output.NullOutputStream;
+import org.dataconservancy.pass.model.File;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests related to uploading binary content to repository resources
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class PostBinaryIT extends ClientITBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IncomingLinksIT.class);
+
+    private static final String EXPECTED_SHA_1 = "0a2f005e7b3fe1a3a658765bc5654d34625991a3";
+
+    private static final String EXPECTED_SLUG = "druid-hill";
+
+    private static final String EXPECTED_CONTENT_TYPE = "image/jpeg";
+
+    private static final String EXPECTED_FILENAME = "dh.jpg";
+
+    private Submission submission;
+
+    private File file;
+
+    private MessageDigestCalculatingInputStream uploadedIn;
+
+    private URI uploaded;
+
+    @Before
+    public void setUp() throws Exception {
+        // Add a Submission
+        submission = new Submission();
+        submission.setSource(Submission.Source.PASS);
+        submission = client.readResource(client.createResource(submission), Submission.class);
+        createdUris.put(submission.getId(), Submission.class);
+
+        // Add a File that references the Submission
+        file = new File();
+        file.setName("FileReferencingSubmission");
+        file.setSubmission(submission.getId());
+        file = client.readResource(client.createResource(file), File.class);
+        createdUris.put(file.getId(), File.class);
+
+        InputStream in = this.getClass().getResourceAsStream(EXPECTED_FILENAME);
+        uploadedIn = new MessageDigestCalculatingInputStream(in, "SHA-1");
+        uploaded = client.upload(submission.getId(), uploadedIn, new HashMap<String, String>() {
+            {
+                put("slug", EXPECTED_SLUG);
+                put("filename", EXPECTED_FILENAME);
+                put("sha1", EXPECTED_SHA_1);
+                put("content-type", EXPECTED_CONTENT_TYPE);
+            }
+        });
+
+        assertNotNull("Expected a URI to the uploaded binary.", uploaded);
+    }
+
+    /**
+     * Insure that binary uploaded to an entity can be retrieved.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void postSimple() throws Exception {
+        try (Response res = okHttp.newCall(getWithAccept(uploaded)).execute()) {
+            MessageDigestCalculatingInputStream mdActualIn = new MessageDigestCalculatingInputStream(
+                    res.body().byteStream(), "SHA-1");
+            IOUtils.copy(mdActualIn, new NullOutputStream());
+
+            byte[] expectedDigest = uploadedIn.getMessageDigest().digest();
+            byte[] actualDigest = mdActualIn.getMessageDigest().digest();
+
+            assertTrue("Unexpected response code: " + res.code(), res.isSuccessful());
+            assertArrayEquals("The checksum for " + uploaded + " differs from the expected value.",
+                    actualDigest, expectedDigest);
+        }
+    }
+
+    /**
+     * Insure the "slug" parameter is honored.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void postWithSlug() throws Exception {
+        assertTrue(uploaded.toString().endsWith(EXPECTED_SLUG));
+    }
+
+    /**
+     * Insure content type header is honored.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void postWithContentType() throws Exception {
+        try (Response res = okHttp.newCall(getWithAccept(uploaded)).execute()) {
+            assertEquals("image/jpeg", res.header("content-type"));
+        }
+    }
+
+    /**
+     * Fedora requires an {@code Accept} header, even when retrieving binary content.
+     *
+     * @param uri the URI to a Fedora resource
+     * @return a Request targeting the resource, which includes the sending of an {@code Accept} header
+     */
+    private static Request getWithAccept(URI uri) {
+        return new Request.Builder()
+                .get()
+                .url(uri.toString())
+                .addHeader("Accept", "*/*")
+                .build();
+    }
+
+}

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
@@ -15,9 +15,11 @@
  */
 package org.dataconservancy.pass.client;
 
+import java.io.InputStream;
 import java.net.URI;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,6 +84,40 @@ public class PassClientDefault implements PassClient {
     @Override
     public Map<String, Collection<URI>> getIncoming(URI passEntity) {
         return crudClient.getIncoming(passEntity);
+    }
+
+    @Override
+    public URI upload(URI entityUri, InputStream content) {
+        return upload(entityUri, content, Collections.emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <h4>Implementation notes</h4>
+     * Supported parameters include:
+     * <dl>
+     *     <dt>content-type</dt>
+     *     <dd>the mime type of the {@code content} to be {@code POST}ed; added as a {@code Content-Type} header</dd>
+     *     <dt>slug</dt>
+     *     <dd>suggested name of the resource in the repository; added as a {@code Slug} header</dd>
+     *     <dt>sha256</dt>
+     *     <dd>hexadecimal encoded SHA-256 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>sha1</dt>
+     *     <dd>hexadecimal encoded SHA-1 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>md5</dt>
+     *     <dd>hexadecimal encoded MD5 checksum of {@code content}; added as {@code Digest} header</dd>
+     *     <dt>filename</dt>
+     *     <dd>name for {@code content}; added to a {@code Content-Disposition} header</dd>
+     * </dl>
+     *
+     * @param entityUri an existing entity in the repository
+     * @param content the content to {@code POST} to the entity
+     * @param params optional parameters to the {@code POST}, <em>i.e.</em> HTTP header values
+     * @return
+     */
+    @Override
+    public URI upload(URI entityUri, InputStream content, Map<String, ?> params) {
+        return crudClient.upload(entityUri, content, params);
     }
 
     /**

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/PassClientDefault.java
@@ -93,27 +93,6 @@ public class PassClientDefault implements PassClient {
 
     /**
      * {@inheritDoc}
-     * <h4>Implementation notes</h4>
-     * Supported parameters include:
-     * <dl>
-     *     <dt>content-type</dt>
-     *     <dd>the mime type of the {@code content} to be {@code POST}ed; added as a {@code Content-Type} header</dd>
-     *     <dt>slug</dt>
-     *     <dd>suggested name of the resource in the repository; added as a {@code Slug} header</dd>
-     *     <dt>sha256</dt>
-     *     <dd>hexadecimal encoded SHA-256 checksum of {@code content}; added as {@code Digest} header</dd>
-     *     <dt>sha1</dt>
-     *     <dd>hexadecimal encoded SHA-1 checksum of {@code content}; added as {@code Digest} header</dd>
-     *     <dt>md5</dt>
-     *     <dd>hexadecimal encoded MD5 checksum of {@code content}; added as {@code Digest} header</dd>
-     *     <dt>filename</dt>
-     *     <dd>name for {@code content}; added to a {@code Content-Disposition} header</dd>
-     * </dl>
-     *
-     * @param entityUri an existing entity in the repository
-     * @param content the content to {@code POST} to the entity
-     * @param params optional parameters to the {@code POST}, <em>i.e.</em> HTTP header values
-     * @return
      */
     @Override
     public URI upload(URI entityUri, InputStream content, Map<String, ?> params) {

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <elasticsearch-client.version>6.2.3</elasticsearch-client.version>
     <slf4j.version>1.7.25</slf4j.version>
     <unitils.version>3.4.6</unitils.version>
+    <okhttp.version>3.10.0</okhttp.version>
   </properties>
 
 
@@ -220,6 +221,18 @@
        <artifactId>openpojo</artifactId>
        <version>${openpojo.version}</version>
        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>${okhttp.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Updates `PassClient` to support the `POST` of binary content to arbitrary repository resources.

The implementation does not assume LDP semantics.  That is, the caller is free to `POST` content to _any_ resource, the implementation does not insure or assume that the resource is an LDP container.

Perhaps more importantly, the implementation does not restrict the caller to `POST`ing content to certain PASS data types.  For example, the caller may `POST` content to a `File` entity just as easily as `POST`ing content to a `Submission`.