### PR TITLE
Model updates: remove Policy.funder, add Repository.integrationType

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-api</artifactId>
   <name>pass-client-api</name>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-integration</artifactId>
 

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-6</name>
+              <name>oapass/fcrepo:4.7.5-2.1-SNAPSHOT</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -100,7 +100,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.6-2.0-SNAPSHOT</name>
+              <name>oapass/indexer:0.0.8-2.1-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -74,9 +74,9 @@
                   <FCREPO_STOMP_PORT>${FCREPO_STOMP_PORT}</FCREPO_STOMP_PORT>
                   <FCREPO_JMS_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</FCREPO_JMS_BASEURL>
                   <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_URI>
-                  <COMPACTION_PRELOAD_URI_PASS_STATIC>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_PRELOAD_URI_PASS_STATIC>
-                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-2.0.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
+                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld</COMPACTION_URI>
+                  <COMPACTION_PRELOAD_URI_PASS_STATIC>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld</COMPACTION_PRELOAD_URI_PASS_STATIC>
+                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-2.1.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
                 </env>
                 <ports>
                   <port>${FCREPO_PORT}:${FCREPO_PORT}</port>

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-util</artifactId>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-data-client</artifactId>
   <name>PASS Data Client</name>

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-json-adapter</artifactId>
   

--- a/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
+++ b/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
@@ -40,7 +40,7 @@ public class PassJsonAdapterBasic implements PassJsonAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(PassJsonAdapterBasic.class);
     
     private final static String CONTEXT_PROPKEY = "pass.jsonld.context";
-    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld";
+    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.1.jsonld";
     
     /**
      * {@inheritDoc}

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-model</artifactId>
   <name>PASS Core Data Model</name>

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Policy.java
@@ -52,11 +52,7 @@ public class Policy extends PassEntity {
      */
     private URI institution;
     
-    /** 
-     * URI of the Funder whose Policy this is (note: if funder has a value, institution should be null)
-     */
-    private URI funder;
-
+    
     /**
      * @return the title
      */
@@ -122,22 +118,6 @@ public class Policy extends PassEntity {
 
     
     /**
-     * @return the funder
-     */
-    public URI getFunder() {
-        return funder;
-    }
-
-    
-    /**
-     * @param institution the institution to set
-     */
-    public void setFunder(URI funder) {
-        this.funder = funder;
-    }
-
-    
-    /**
      * @return the list of URIs of repositories
      */
     public List<URI> getRepositories() {
@@ -165,7 +145,6 @@ public class Policy extends PassEntity {
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (policyUrl != null ? !policyUrl.equals(that.policyUrl) : that.policyUrl != null) return false;
         if (repositories != null ? !repositories.equals(that.repositories) : that.repositories != null) return false;
-        if (funder != null ? !funder.equals(that.funder) : that.funder != null) return false;
         if (institution != null ? !institution.equals(that.institution) : that.institution != null) return false;
         return true;
     }
@@ -179,7 +158,6 @@ public class Policy extends PassEntity {
         result = 31 * result + (policyUrl != null ? policyUrl.hashCode() : 0);
         result = 31 * result + (repositories != null ? repositories.hashCode() : 0);
         result = 31 * result + (institution != null ? institution.hashCode() : 0);
-        result = 31 * result + (funder != null ? funder.hashCode() : 0);
         return result;
     }
        

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
@@ -17,6 +17,11 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Describes a Repository. A Repository is the target of a Deposit.
  * @author Karen Hanson
@@ -44,6 +49,56 @@ public class Repository extends PassEntity {
      */
     private String formSchema;
 
+    /** 
+     * Type of integration PASS has with the Repository
+     */
+    private IntegrationType integrationType;
+    
+
+    /**
+     * Possible deposit statuses. Note that some repositories may not go through every status.
+     */
+    public enum IntegrationType {
+        /**
+         * PASS can make Deposits to this Repository, and will received updates about its status
+         */
+        @JsonProperty("full")
+        FULL("full"),
+         /**
+         * PASS can make Deposits to this Repository but will not automatically receive updates about its status
+         */
+        @JsonProperty("one-way")
+        ONE_WAY("one-way"),
+        /**
+        * A deposit cannot automatically be made to this Repository from PASS, only a web link can be created.
+        */
+        @JsonProperty("web-link")
+        WEB_LINK("web-link");
+
+        private static final Map<String, IntegrationType> map = new HashMap<>(values().length, 1);  
+        static {
+          for (IntegrationType d : values()) map.put(d.value, d);
+        }
+        
+        private String value;
+        private IntegrationType(String value){
+            this.value = value;
+        }
+        
+        public static IntegrationType of(String integrationType) {
+            IntegrationType result = map.get(integrationType);
+            if (result == null) {
+              throw new IllegalArgumentException("Invalid Integration Type: " + integrationType);
+            }
+            return result;
+        }
+        
+        @Override
+        public String toString() {
+            return this.value;
+        }
+        
+    }
     
     /**
      * @return the name
@@ -109,6 +164,22 @@ public class Repository extends PassEntity {
     }
 
 
+    /**
+     * @return the integrationType
+     */
+    public IntegrationType getIntegrationType() {
+        return integrationType;
+    }
+
+
+    /**
+     * @param integrationType the integrationType to set
+     */
+    public void setIntegrationType(IntegrationType integrationType) {
+        this.integrationType = integrationType;
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -121,6 +192,7 @@ public class Repository extends PassEntity {
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (url != null ? !url.equals(that.url) : that.url != null) return false;
         if (formSchema != null ? !formSchema.equals(that.formSchema) : that.formSchema != null) return false;
+        if (integrationType != null ? !integrationType.equals(that.integrationType) : that.integrationType != null) return false;
         return true;
     }
 
@@ -132,6 +204,7 @@ public class Repository extends PassEntity {
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (url != null ? url.hashCode() : 0);
         result = 31 * result + (formSchema != null ? formSchema.hashCode() : 0);
+        result = 31 * result + (integrationType != null ? integrationType.hashCode() : 0);
         return result;
     }
     

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/PolicyModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/PolicyModelTests.java
@@ -55,7 +55,6 @@ public class PolicyModelTests {
         assertEquals(TestValues.REPOSITORY_ID_1, policy.getRepositories().get(0).toString());
         assertEquals(TestValues.REPOSITORY_ID_2, policy.getRepositories().get(1).toString());
         assertEquals(TestValues.POLICY_URL, policy.getPolicyUrl().toString());
-        assertEquals(TestValues.FUNDER_ID_1, policy.getFunder().toString());
         assertEquals(TestValues.INSTITUTION_ID_1, policy.getInstitution().toString());
     }
 
@@ -80,7 +79,6 @@ public class PolicyModelTests {
         assertEquals(root.getJSONArray("repositories").get(0),TestValues.REPOSITORY_ID_1);
         assertEquals(root.getJSONArray("repositories").get(1),TestValues.REPOSITORY_ID_2);
         assertEquals(root.getString("institution"),TestValues.INSTITUTION_ID_1);         
-        assertEquals(root.getString("funder"),TestValues.FUNDER_ID_1);         
     }
     
     /**
@@ -118,7 +116,6 @@ public class PolicyModelTests {
         policy.setRepositories(repositories);
 
         policy.setInstitution(new URI(TestValues.INSTITUTION_ID_1));
-        policy.setFunder(new URI(TestValues.FUNDER_ID_1));
         
         return policy;
     }

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
+import org.dataconservancy.pass.model.Repository.IntegrationType;
 import org.json.JSONObject;
 
 import static org.junit.Assert.assertEquals;
@@ -51,6 +52,7 @@ public class RepositoryModelTests {
         assertEquals(TestValues.REPOSITORY_DESCRIPTION, repository.getDescription());
         assertEquals(TestValues.REPOSITORY_URL, repository.getUrl().toString());
         assertEquals(TestValues.REPOSITORY_FORMSCHEMA, repository.getFormSchema());
+        assertEquals(TestValues.REPOSITORY_INTEGRATION_TYPE, repository.getIntegrationType().toString());
     }
 
     /**
@@ -71,7 +73,8 @@ public class RepositoryModelTests {
         assertEquals(root.getString("name"),TestValues.REPOSITORY_NAME);
         assertEquals(root.getString("description"),TestValues.REPOSITORY_DESCRIPTION);
         assertEquals(root.getString("url"),TestValues.REPOSITORY_URL);        
-        assertEquals(root.getString("formSchema"),TestValues.REPOSITORY_FORMSCHEMA);          
+        assertEquals(root.getString("formSchema"),TestValues.REPOSITORY_FORMSCHEMA); 
+        assertEquals(root.getString("integrationType"),TestValues.REPOSITORY_INTEGRATION_TYPE);
     }
     
     /**
@@ -103,6 +106,7 @@ public class RepositoryModelTests {
         repository.setDescription(TestValues.REPOSITORY_DESCRIPTION);
         repository.setUrl(new URI(TestValues.REPOSITORY_URL));
         repository.setFormSchema(TestValues.REPOSITORY_FORMSCHEMA);
+        repository.setIntegrationType(IntegrationType.of(TestValues.REPOSITORY_INTEGRATION_TYPE));
         
         return repository;
     }

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>pass-test-data</artifactId>
   <name>PASS Test Data</name>

--- a/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
+++ b/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
@@ -94,6 +94,7 @@ public class TestValues {
     public static final String REPOSITORY_URL = "https://repo-example.org/";
     //TODO: verify format of formSchema field
     public static final String REPOSITORY_FORMSCHEMA = "{\"customFieldName\": \"String\"}";
+    public static final String REPOSITORY_INTEGRATION_TYPE = "web-link";
     
     public static final String REPOSITORYCOPY_STATUS = "accepted";
     public static final String REPOSITORYCOPY_EXTERNALID_1 = "PMC12345";

--- a/pass-test-data/src/main/resources/policy.json
+++ b/pass-test-data/src/main/resources/policy.json
@@ -5,7 +5,6 @@
 	"description": "You must submit to any OA repo",
 	"policyUrl": "https://somefunder.org/policy",
 	"repositories": ["https://example.org/fedora/repositories/1","https://example.org/fedora/repositories/2"],
-	"institution": "https://example.org/fedora/institutions/1",
-	"funder": "https://example.org/fedora/funders/1"
+	"institution": "https://example.org/fedora/institutions/1"
 }
 	

--- a/pass-test-data/src/main/resources/repository.json
+++ b/pass-test-data/src/main/resources/repository.json
@@ -4,6 +4,7 @@
 	"name": "Repository A",
 	"description": "An OA repository run by funder A",
 	"url": "https://repo-example.org/",
-	"formSchema":"{\"customFieldName\": \"String\"}"
+	"formSchema":"{\"customFieldName\": \"String\"}",
+	"integrationType":"web-link"
 }
 	

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   
   <name>PASS Client Tool</name>
   


### PR DESCRIPTION
Reflects latest pass-data-model changes. 
* Removing Policy.funder gets rid of a bi-directional link
* IntegrationType is a new enum value for Repository to describe the type of integration PASS has with the Repository. 

Version incremented to 0.3.1-SNAPSHOT since model has changed.