### PR TITLE
Updates the OkHttpClient configuration used by FedoraPassCrudClient

### DIFF
--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -139,6 +139,17 @@ public class FedoraPassCrudClient {
             okBuilder.addInterceptor(loggingInterceptor);
         }
 
+        String userAgent = System.getProperty("http.agent");
+        if (userAgent != null) {
+            LOG.trace("Adding 'User-Agent' header with value: {}", userAgent);
+            okBuilder.addInterceptor((requestChain) -> {
+                Request.Builder reqBuilder = requestChain.request().newBuilder();
+                reqBuilder.removeHeader("User-Agent");
+                reqBuilder.addHeader("User-Agent", userAgent);
+                return requestChain.proceed(reqBuilder.build());
+            });
+        }
+
         this.okHttpClient = okBuilder.build();
     }
 

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -119,11 +119,13 @@ public class FedoraPassCrudClient {
 
         OkHttpClient.Builder okBuilder = new OkHttpClient.Builder();
 
-        // N.B. this presumes that this OkHttp client will _only_ communicate with the Fedora repository, otherwise
-        // authorization credentials will be leaked.
         if (FedoraConfig.getUserName() != null) {
             okBuilder.addInterceptor((requestChain) -> {
                 Request request = requestChain.request();
+                if (!request.url().toString().startsWith(FedoraConfig.getBaseUrl())) {
+                    return requestChain.proceed(request);
+                }
+                LOG.trace("Adding 'Authorization' header for communication with {}", FedoraConfig.getBaseUrl());
                 Request.Builder reqBuilder = request.newBuilder();
                 byte[] bytes = format("%s:%s",
                         FedoraConfig.getUserName(), FedoraConfig.getPassword()).getBytes();


### PR DESCRIPTION
Insures authorization credentials do not leak to origin servers other than the Fedora server.
Insures compatibility with the Apache Http Client for setting the User-Agent using the `http.agent` system property.