### PR TITLE
Remove origin check when adding Authorization header to OkHttpClient requests

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-api</artifactId>
   <name>pass-client-api</name>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-integration</artifactId>
 

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-util</artifactId>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-data-client</artifactId>
   <name>PASS Data Client</name>

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FedoraPassCrudClient.java
@@ -122,9 +122,6 @@ public class FedoraPassCrudClient {
         if (FedoraConfig.getUserName() != null) {
             okBuilder.addInterceptor((requestChain) -> {
                 Request request = requestChain.request();
-                if (!request.url().toString().startsWith(FedoraConfig.getBaseUrl())) {
-                    return requestChain.proceed(request);
-                }
                 LOG.trace("Adding 'Authorization' header for communication with {}", FedoraConfig.getBaseUrl());
                 Request.Builder reqBuilder = request.newBuilder();
                 byte[] bytes = format("%s:%s",

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-json-adapter</artifactId>
   

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-model</artifactId>
   <name>PASS Core Data Model</name>

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
   </parent>
   <artifactId>pass-test-data</artifactId>
   <name>PASS Test Data</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.3.3-SNAPSHOT</version>
   
   <name>PASS Client Tool</name>
   


### PR DESCRIPTION
Remove origin server check when the caller of the client has a different view of the Fedora base url than the client configuration.

For example, a caller who believes (correctly) that the base url of the Fedora repository is http://fcrepo:8080/fcrepo/rest but the PassClient is configured with an equivalent (also correct) url of http://192.168.99.100:8080/fcrepo/rest, the call will not get an Authorization header, and the request will fail.

Update version to 0.3.3-SNAPSHOT.