### PR TITLE
Assign URIs to each DepositStatus value.

### DIFF
--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Constants.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Constants.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.model;
+
+import java.net.URI;
+
+/**
+ * Constants used throughout the PASS Java client.  Used to align the 
+ * <a href="https://github.com/OA-PASS/pass-data-model/blob/master/README.md">model documentation</a> with
+ * implementation.
+ * 
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+class Constants {
+    
+    private Constants() {
+        // prevent instantiation
+    }
+
+    /**
+     * The PASS URI.
+     */
+    static final String OAPASS_BASE_URI = "http://oapass.org/";
+
+    /**
+     * Base URI used when identifying concepts relating to PASS.
+     */
+    static final String OAPASS_NS_URI = OAPASS_BASE_URI + "ns/";
+
+    /**
+     * Codifies Deposit statuses as documented <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">here</a>
+     */
+    static final class DepositStatus {
+
+        private DepositStatus() {
+            // prevent instantiation
+        }
+        
+        /**
+         * String representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code submitted} state.
+         */
+        static final String SUBMITTED_STATUS = "submitted";
+
+        /**
+         * String representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code rejected} state.
+         */
+        static final String REJECTED_STATUS = "rejected";
+
+        /**
+         * String representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code failed} state.
+         */
+        static final String FAILED_STATUS = "failed";
+
+        /**
+         * String representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code accepted} state.
+         */
+        static final String ACCEPTED_STATUS = "accepted";
+
+        /**
+         * The base URI used to represent the status of <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> resources.
+         */
+        static final URI STATUS_BASE_URI = URI.create(Constants.OAPASS_NS_URI + "status/deposit#");
+
+        /**
+         * URI representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code submitted} state.
+         */
+        static final URI SUBMITTED_URI = URI.create(STATUS_BASE_URI + SUBMITTED_STATUS);
+
+        /**
+         * URI representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code rejected} state.
+         */
+        static final URI REJECTED_URI = URI.create(STATUS_BASE_URI + REJECTED_STATUS);
+
+        /**
+         * URI representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code failed} state.
+         */
+        static final URI FAILED_URI = URI.create(STATUS_BASE_URI + FAILED_STATUS);
+
+        /**
+         * URI representation of a <a href="https://github.com/OA-PASS/pass-data-model/blob/master/documentation/Deposit.md">Deposit</a> status in the {@code accepted} state.
+         */
+        static final URI ACCEPTED_URI = URI.create(STATUS_BASE_URI + ACCEPTED_STATUS);
+
+    }
+
+}

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Deposit.java
@@ -17,10 +17,18 @@ package org.dataconservancy.pass.model;
 
 import java.net.URI;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static org.dataconservancy.pass.model.Constants.DepositStatus.ACCEPTED_STATUS;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.ACCEPTED_URI;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.FAILED_STATUS;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.FAILED_URI;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.REJECTED_STATUS;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.REJECTED_URI;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.SUBMITTED_STATUS;
+import static org.dataconservancy.pass.model.Constants.DepositStatus.SUBMITTED_URI;
 
 /**
  * A Submission can have multiple Deposits, each to a different Repository. This describes a single deposit to a Repository and captures 
@@ -29,7 +37,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class Deposit extends PassEntity {
-    
+
+    static final String STATUS_NS = "http://oapass.org/ns/status/deposit#";
+
     /** 
      * A URL or some kind of reference that can be dereferenced, entity body parsed, and used to determine the status of Deposit
      */
@@ -57,48 +67,89 @@ public class Deposit extends PassEntity {
     
     /**
      * Possible deposit statuses. Note that some repositories may not go through every status.
+     * <dl>
+     *     <dt>Intermediate status</dt>
+     *     <dd>A {@code Deposit} with an <em>intermediate</em> status indicates that the processing of the
+     *         {@code Deposit} is not yet complete.  At some indeterminate point in the future, the status <em>may</em>
+     *         be updated to a <em>terminal</em> state.</dd>
+     *     <dt>Terminal status</dt>
+     *     <dd>A {@code Deposit} with a <em>terminal</em> status indicates that the processing of the {@code Deposit}
+     *         is complete.</dd>
+     * </dl>
      */
     public enum DepositStatus {
-        /**
-         * PASS has sent a package to the target Repository and is waiting for an update on the status
-         */
-        @JsonProperty("submitted")
-        SUBMITTED("submitted"),
-         /**
-         * The target Repository has rejected the Deposit
-         */
-        @JsonProperty("accepted")
-        ACCEPTED("accepted"),
-        /**
-        * The target Repository has accepted the files into the repository. More steps may be performed by the Repository, but the 
-        * requirements of the Deposit have been satisfied
-        */
-        @JsonProperty("rejected")
-        REJECTED("rejected"),
-        /**
-         * A failure occurred performing the deposit; it may be re-tried later.
-         */
-        @JsonProperty("failed")
-        FAILED("failed");
 
-        private static final Map<String, DepositStatus> map = new HashMap<>(values().length, 1);  
-        static {
-          for (DepositStatus d : values()) map.put(d.value, d);
-        }
+        /**
+         * PASS has sent a package to the target {@code Repository} and is waiting for an update on the status.  This
+         * is considered an <em>intermediate</em> state.  The {@link Deposit#getDepositStatusRef() Deposit status
+         * reference} (if it exists) can be periodically consulted to determine the current state of the
+         * {@code Deposit}.
+         */
+        @JsonProperty(SUBMITTED_STATUS)
+        SUBMITTED(SUBMITTED_URI, SUBMITTED_STATUS),
+
+        /**
+         * The target {@code Repository} has accepted custody of the materials represented by the {@code Deposit}.  This
+         * is considered a <em>terminal</em> state.
+         */
+        @JsonProperty(ACCEPTED_STATUS)
+        ACCEPTED(ACCEPTED_URI, ACCEPTED_STATUS),
+
+       /**
+        * The target {@code Repository} has rejected custody of the materials represented by the {@code Deposit}.  This
+        * is considered a <em>terminal</em> state.
+        */
+        @JsonProperty(REJECTED_STATUS)
+        REJECTED(REJECTED_URI, REJECTED_STATUS),
+
+        /**
+         * A failure occurred performing the deposit; it may be re-tried later.  This is considered an
+         * <em>intermediate</em> state.
+         */
+        @JsonProperty(FAILED_STATUS)
+        FAILED(FAILED_URI, FAILED_STATUS);
+
+        private URI uri;
         
         private String value;
-        private DepositStatus(String value){
+
+        private DepositStatus(URI uri, String value) {
+            this.uri = uri;
             this.value = value;
         }
-        
+
+        /**
+         * Parses a string representation as a {@code DepositStatus}
+         *
+         * @param status a URI or string form of a {@code DepositStatus}
+         * @return the status
+         * @throws IllegalArgumentException if the supplied {@code status} does not represent a valid
+         *         {@code DepositStatus}
+         */
         public static DepositStatus of(String status) {
-            DepositStatus result = map.get(status);
-            if (result == null) {
-              throw new IllegalArgumentException("Invalid Deposit Status: " + status);
-            }
-            return result;
+            return Stream.of(values()).filter(candidate ->
+                    candidate.value.equals(status) || candidate.uri.toString().equals(status)).findAny()
+                        .orElseThrow(() -> new IllegalArgumentException("Invalid Deposit Status: " + status));
         }
-        
+
+        /**
+         * The {@code String} representation of {@code Deposit.DepositStatus}
+         *
+         * @return a string representing this {@code DepositStatus}
+         */
+        String getValue() {
+            return value;
+        }
+
+        /**
+         * The {@code URI} representation of {@code Deposit.DepositStatus}
+         *
+         * @return a URI representing this {@code DepositStatus}
+         */
+        public URI asUri() {
+            return uri;
+        }
+
         @Override
         public String toString() {
             return this.value;

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/DepositStatusTest.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/DepositStatusTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.model;
+
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class DepositStatusTest {
+
+    /**
+     * Insure no typos used in DepositStatus value and URI.  If this test fails and there are no typos, adjust this
+     * test.
+     */
+    @Test
+    public void statusValueAndUriSanityCheck() {
+        Stream.of(Deposit.DepositStatus.values()).forEach(depositStatus -> {
+            assertTrue(depositStatus.asUri().toString().endsWith(depositStatus.getValue()));
+        });
+    }
+
+    /**
+     * Insures the DepositStatus can be looked up by URI and by string value.
+     */
+    @Test
+    public void lookupByValueAndUri() {
+        Stream.of(Deposit.DepositStatus.values()).forEach(depositStatus -> {
+            assertEquals(depositStatus, Deposit.DepositStatus.of(depositStatus.getValue()));
+            assertEquals(depositStatus, Deposit.DepositStatus.of(depositStatus.asUri().toString()));
+        });
+    }
+}


### PR DESCRIPTION
Allow DepositStatus to be represented as a URI, and to be looked up by URI.  Records fixed strings as constants, and includes unit tests.

Brings the java client into alignment with the DepositStatus URIs proposed [here](https://github.com/OA-PASS/pass-data-model/pull/37).

