### PR TITLE
Update to latest fcrepo image for ITs

### DIFF
--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.2-SNAPSHOT</name>
+              <name>oapass/fcrepo:4.7.5-2.3-SNAPSHOT</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -74,9 +74,6 @@
                   <FCREPO_STOMP_PORT>${FCREPO_STOMP_PORT}</FCREPO_STOMP_PORT>
                   <FCREPO_JMS_BASEURL>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</FCREPO_JMS_BASEURL>
                   <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                  <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_URI>
-                  <COMPACTION_PRELOAD_URI_PASS_STATIC>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_PRELOAD_URI_PASS_STATIC>
-                  <COMPACTION_PRELOAD_FILE_PASS_STATIC>/usr/local/tomcat/lib/context-2.2.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
                 </env>
                 <ports>
                   <port>${FCREPO_PORT}:${FCREPO_PORT}</port>
@@ -92,7 +89,7 @@
                 </volumes>
                 <wait>
                   <http>
-                    <url>http://admin:moo@${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</url>
+                    <url>http://fedoraAdmin:moo@${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest</url>
                   </http>
                   <time>120000</time>
                 </wait>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
@@ -75,6 +75,9 @@ public abstract class ClientITBase {
         if (System.getProperty("pass.fedora.baseurl") == null) {
             System.setProperty("pass.fedora.baseurl", "http://localhost:8080/fcrepo/rest/");
         }
+        if (System.getProperty("pass.fedora.user") == null) {
+            System.setProperty("pass.fedora.user", "fedoraAdmin");
+        }
         if (System.getProperty("pass.elasticsearch.url") == null) {
             System.setProperty("pass.elasticsearch.url", "http://localhost:9200/pass/");
         }


### PR DESCRIPTION
Bumps to the latest fcrepo docker image for ITs, and removes hardcoded
compaction settings (which are now enabled by default in the fcrepo image)