### PR TITLE
Update model to version 3.0 in order to support new proxy user features

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-api</artifactId>
   <name>pass-client-api</name>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-integration</artifactId>
 

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -63,7 +63,7 @@
           <images>
             <image>
               <alias>fcrepo</alias>
-              <name>oapass/fcrepo:4.7.5-2.3-SNAPSHOT</name>
+              <name>oapass/fcrepo:4.7.5-3.0-SNAPSHOT</name>
               <run>
                 <hostname>fcrepo</hostname>
                 <namingStrategy>alias</namingStrategy>
@@ -97,7 +97,7 @@
             </image>
             <image>
               <alias>indexer</alias>
-              <name>oapass/indexer:0.0.13-2.3-SNAPSHOT</name>
+              <name>oapass/indexer:0.0.14-3.0-SNAPSHOT</name>
               <run>
                 <namingStrategy>alias</namingStrategy>
                 <env>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
@@ -31,7 +31,7 @@ import org.dataconservancy.pass.model.Grant;
 import org.dataconservancy.pass.model.Grant.AwardStatus;
 import org.dataconservancy.pass.model.PassEntity;
 import org.dataconservancy.pass.model.Submission;
-import org.dataconservancy.pass.model.Submission.AggregatedDepositStatus;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
 import org.dataconservancy.pass.model.User;
 
 import static org.junit.Assert.assertEquals;
@@ -94,25 +94,25 @@ public class FindAllByAttributesIT extends ClientITBase {
 
     @Test
     public void testFindSubmissionWithNoSource() throws Exception {
-        URI user = URI.create("http://example.com/user");
+        URI user = URI.create("http://example.com/user/1");
         Submission submission1 = random(Submission.class, 1);
         submission1.setSource(null);
         submission1.setMetadata("foo");
-        submission1.setUser(user);
+        submission1.setSubmitter(user);
         URI expectedUri1 = client.createResource(submission1);
         createdUris.put(expectedUri1, Submission.class);
 
         Submission submission2 = random(Submission.class, 1);
         submission2.setSource(null);
         submission2.setMetadata("foo");
-        submission2.setUser(user);
+        submission2.setSubmitter(user);
         URI expectedUri2 = client.createResource(submission2);
         createdUris.put(expectedUri2, Submission.class);
 
         Submission submission3 = random(Submission.class, 1);
         submission2.setSource(Submission.Source.OTHER);
         submission2.setMetadata("foo");
-        submission2.setUser(user);
+        submission2.setSubmitter(user);
         URI expectedUri3 = client.createResource(submission3);
         createdUris.put(expectedUri3, User.class);
 
@@ -134,7 +134,7 @@ public class FindAllByAttributesIT extends ClientITBase {
         Set<URI> uris = client.findAllByAttributes(Submission.class, new HashMap<String, Object>() {{
             put("metadata", "foo");
             put("source", null);
-            put("user", user);
+            put("submitter", user);
         }});
 
         // Only the two Submissions with null sources should be found.  The other Submission has a non-null source,
@@ -189,7 +189,6 @@ public class FindAllByAttributesIT extends ClientITBase {
         assertEquals(2, matches.size());
 
     }
-    
     
     
     /**
@@ -290,7 +289,7 @@ public class FindAllByAttributesIT extends ClientITBase {
             Map<String,Object> map = new HashMap<String,Object>();
             List<URI> coll = new ArrayList<URI>(); 
             map.put("repositories", coll);
-            map.put("AggregatedDepositStatus", AggregatedDepositStatus.ACCEPTED);
+            map.put("SubmissionStatus", SubmissionStatus.ACCEPTED);
             client.findAllByAttributes(Submission.class, map);
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("cannot be a Collection"));

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
@@ -123,6 +123,28 @@ public class FindByAttributeIT extends ClientITBase {
     }
     
     /**
+     * Confirm that a search on Submission.submitter that has a `mailto:` instead of a `User.id` still matches
+     * when used in a findByAttribute
+     */
+    @Test
+    public void testSubmissionWithMailtoUser() throws Exception {
+        String emailStr = "mailto:Lesley%20Smith%3Clesleysmith%40example.org%3E";
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitter(new URI(emailStr));
+        final URI submissionid = client.createResource(submission); //create something so it's not empty
+        createdUris.put(submissionid, Submission.class);
+        
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(Submission.class, "@id", submissionid);
+            assertEquals(submissionid, uri);
+        });
+        
+        URI matchedId = client.findByAttribute(Submission.class, "submitter", emailStr);
+        assertEquals(submissionid, matchedId);
+        
+    }
+    
+    /**
      * Ensures that a search on a field of type multi-line array with multi values in it works
      * in this case it uses the repositories list in Submission as an example
      */

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-util</artifactId>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-data-client</artifactId>
   <name>PASS Data Client</name>

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-json-adapter</artifactId>
   

--- a/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
+++ b/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
@@ -40,7 +40,7 @@ public class PassJsonAdapterBasic implements PassJsonAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(PassJsonAdapterBasic.class);
     
     private final static String CONTEXT_PROPKEY = "pass.jsonld.context";
-    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.3.jsonld";
+    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.0.jsonld";
     
     /**
      * {@inheritDoc}

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-model</artifactId>
   <name>PASS Core Data Model</name>

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntityType.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/PassEntityType.java
@@ -33,6 +33,7 @@ public enum PassEntityType {
     REPOSITORY ("Repository", "repositories"),
     REPOSITORY_COPY ("RepositoryCopy", "repositoryCopies"),
     SUBMISSION ("Submission", "submissions"),
+    SUBMISSION_EVENT ("SubmissionEvent", "submissionEvents"),
     USER ("User", "users");
     
     private String name;

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Repository.java
@@ -44,6 +44,11 @@ public class Repository extends PassEntity {
      */
     private URI url;
 
+    /**
+     * The legal text that a submitter must agree to in order to submit a publication to this repository
+     */
+    private String agreementText;
+        
     /** 
      * Stringified JSON representing a form template to be loaded by the front-end when this Repository is selected
      */
@@ -154,6 +159,22 @@ public class Repository extends PassEntity {
 
     
     /**
+     * @return the agreement text
+     */
+    public String getAgreementText() {
+        return agreementText;
+    }
+
+    
+    /**
+     * @param agreementText the agreement text to set
+     */
+    public void setAgreementText(String agreementText) {
+        this.agreementText = agreementText;
+    }
+
+    
+    /**
      * @return the formSchema
      */
     public String getFormSchema() {
@@ -162,7 +183,7 @@ public class Repository extends PassEntity {
 
     
     /**
-     * @param url the url to set
+     * @param formSchema the form schema to set
      */
     public void setFormSchema(String formSchema) {
         this.formSchema = formSchema;

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
@@ -71,7 +71,8 @@ public class Submission extends PassEntity {
     private URI publication;
     
     /** 
-     * List of repositories that the submission will be deposited to 
+     * List of repositories that the submission will be deposited to
+     * Note that the order of the list does not carry any particular significance 
      */
     private List<URI> repositories = new ArrayList<>();
 
@@ -87,11 +88,13 @@ public class Submission extends PassEntity {
      * URI of the User(s) who prepared, or who could contribute to the preparation of, the Submission.
      * Prepares can edit the content of the Submission (describe the Publication, add Grants, add Files, 
      * select Repositories) but cannot approve any Repository agreements or submit the Publication.
+     * Note that the order of the list does not carry any particular significance
      */
     private List<URI> preparers = new ArrayList<>();
     
     /** 
      * List of URIs for grants associated with the submission 
+     * Note that the order of the list does not carry any particular significance
      */
     private List<URI> grants = new ArrayList<>();
     

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/SubmissionEvent.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/SubmissionEvent.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.model;
+
+import java.net.URI;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.dataconservancy.pass.model.support.ZuluDateTimeDeserializer;
+import org.dataconservancy.pass.model.support.ZuluDateTimeSerializer;
+import org.joda.time.DateTime;
+
+/**
+ * The SubmissionEvent model captures significant events that are performed by an agent and occur against a Submission. 
+ * @author Karen Hanson
+ */
+
+public class SubmissionEvent extends PassEntity {
+
+    /** 
+     * The type of event
+     */
+    private EventType eventType;
+
+    /** 
+     * Date the event was performed by the User
+     */
+    @JsonSerialize(using = ZuluDateTimeSerializer.class)
+    @JsonDeserialize(using = ZuluDateTimeDeserializer.class)
+    private DateTime performedDate;
+    
+    /**
+     * URI of the User responsible for performing the event
+     */
+    private URI performedBy;
+
+    /** 
+     * Role of the person performing the event
+     */
+    private PerformerRole performerRole;
+    
+    /** 
+     * List of repositories that the submission will be deposited to 
+     */
+    private URI submission;
+
+    /**
+     * A comment relevant to the SubmissionEvent. For example, when a `changes-requested` event occurs, 
+     * this might be added by the User through the UI to communicate what changes should be made
+     */
+    private String comment;
+
+    /** 
+     * A resource relevant to the SubmissionEvent. For example, when a `changes-requested` event occurs, 
+     * this may contain an Ember application URL to the affected Submission.
+     */
+    private URI link;
+    
+    /** 
+     * The types of events that might be recorded as SubmissionEvents
+     */
+    public enum EventType {
+        /**
+         * A Submission was prepared by a preparer on behalf of a person who does not yet have a User 
+         * record in PASS. The preparer is requesting that the submitter join PASS and then approve and 
+         * submit it or provide feedback.
+         */
+        @JsonProperty("approval-requested-newuser")
+        APPROVAL_REQUESTED_NEWUSER("approval-requested-newuser"),
+        
+        /**
+         * A Submission was prepared by a preparer who is now requesting that the submitter approve and 
+         * submit it or provide feedback
+         */
+        @JsonProperty("approval-requested")
+        APPROVAL_REQUESTED("approval-requested"),
+        
+        /**
+         * A Submission was prepared by a preparer, but on review by the submitter, a change was requested. 
+         * The Submission has been handed back to the preparer for editing.
+         */
+        @JsonProperty("changes-requested")
+        CHANGES_REQUESTED("changes-requested"),
+
+        /**
+         *  A Submission was prepared and then cancelled by the submitter or preparer without being submitted. 
+         *  No further edits can be made to the Submission.
+         */
+        @JsonProperty("cancelled")
+        CANCELLED("cancelled"),
+        
+        /**
+         * The submit button has been pressed through the UI.
+         */
+        @JsonProperty("submitted")
+        SUBMITTED("submitted");
+
+        private static final Map<String, EventType> map = new HashMap<>(values().length, 1);  
+        static {
+          for (EventType s : values()) map.put(s.value, s);
+        }
+        
+        private String value;
+        
+        private EventType(String value){
+            this.value = value;
+        }
+        
+        public static EventType of(String eventType) {
+            EventType result = map.get(eventType);
+            if (result == null) {
+              throw new IllegalArgumentException("Invalid Event Type: " + eventType);
+            }
+            return result;
+          }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+        
+    }
+
+
+    /** 
+     * Roles of agents who might perform a SubmissionEvent
+     */
+    public enum PerformerRole {
+        @JsonProperty("preparer")
+        PREPARER("preparer"),
+        @JsonProperty("submitter")
+        SUBMITTER("submitter");
+        
+        private String value;
+        
+        private PerformerRole(String value){
+            this.value = value;
+        }
+        
+        @Override
+        public String toString() {
+            return this.value;
+        }
+    }
+    
+    
+    /**
+     * @return the eventType
+     */
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    
+    /**
+     * @param eventType the eventType to set
+     */
+    public void setEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    
+    /**
+     * @return the performedDate
+     */
+    public DateTime getPerformedDate() {
+        return performedDate;
+    }
+
+    
+    /**
+     * @param performedDate the performedDate to set
+     */
+    public void setPerformedDate(DateTime performedDate) {
+        this.performedDate = performedDate;
+    }
+
+    
+    /**
+     * @return the performedBy
+     */
+    public URI getPerformedBy() {
+        return performedBy;
+    }
+
+    
+    /**
+     * @param performedBy the performedBy to set
+     */
+    public void setPerformedBy(URI performedBy) {
+        this.performedBy = performedBy;
+    }
+
+    
+    /**
+     * @return the performerRole
+     */
+    public PerformerRole getPerformerRole() {
+        return performerRole;
+    }
+
+    
+    /**
+     * @param performerRole the performerRole to set
+     */
+    public void setPerformerRole(PerformerRole performerRole) {
+        this.performerRole = performerRole;
+    }
+
+    
+    /**
+     * @return the submission
+     */
+    public URI getSubmission() {
+        return submission;
+    }
+
+    
+    /**
+     * @param submission the submission to set
+     */
+    public void setSubmission(URI submission) {
+        this.submission = submission;
+    }
+
+    
+    /**
+     * @return the comment
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    
+    /**
+     * @param comment the comment to set
+     */
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    
+    /**
+     * @return the link
+     */
+    public URI getLink() {
+        return link;
+    }
+
+    
+    /**
+     * @param link the link to set
+     */
+    public void setLink(URI link) {
+        this.link = link;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        SubmissionEvent that = (SubmissionEvent) o;
+
+        if (eventType != null ? !eventType.equals(that.eventType) : that.eventType != null) return false;
+        if (performedDate != null ? !performedDate.equals(that.performedDate) : that.performedDate != null) return false;
+        if (performedBy != null ? !performedBy.equals(that.performedBy) : that.performedBy != null) return false;
+        if (performerRole != null ? !performerRole.equals(that.performerRole) : that.performerRole != null) return false;
+        if (submission != null ? !submission.equals(that.submission) : that.submission != null) return false;    
+        if (comment != null ? !comment.equals(that.comment) : that.comment != null) return false;            
+        if (link != null ? !link.equals(that.link) : that.link != null) return false;
+        return true;
+    }
+
+    
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (eventType != null ? eventType.hashCode() : 0);
+        result = 31 * result + (performedDate != null ? performedDate.hashCode() : 0);
+        result = 31 * result + (performedBy != null ? performedBy.hashCode() : 0);
+        result = 31 * result + (performerRole != null ? performerRole.hashCode() : 0);
+        result = 31 * result + (submission != null ? submission.hashCode() : 0);
+        result = 31 * result + (comment != null ? comment.hashCode() : 0);
+        result = 31 * result + (link != null ? link.hashCode() : 0);
+        return result;
+    }
+
+}

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/RepositoryModelTests.java
@@ -53,6 +53,7 @@ public class RepositoryModelTests {
         assertEquals(TestValues.REPOSITORY_URL, repository.getUrl().toString());
         assertEquals(TestValues.REPOSITORY_FORMSCHEMA, repository.getFormSchema());
         assertEquals(TestValues.REPOSITORY_INTEGRATION_TYPE, repository.getIntegrationType().toString());
+        assertEquals(TestValues.REPOSITORY_AGREEMENTTEXT, repository.getAgreementText().toString());
     }
 
     /**
@@ -72,9 +73,11 @@ public class RepositoryModelTests {
         assertEquals(root.getString("@type"),"Repository");
         assertEquals(root.getString("name"),TestValues.REPOSITORY_NAME);
         assertEquals(root.getString("description"),TestValues.REPOSITORY_DESCRIPTION);
-        assertEquals(root.getString("url"),TestValues.REPOSITORY_URL);        
+        assertEquals(root.getString("url"),TestValues.REPOSITORY_URL);
+        assertEquals(root.getString("agreementText"), TestValues.REPOSITORY_AGREEMENTTEXT);
         assertEquals(root.getString("formSchema"),TestValues.REPOSITORY_FORMSCHEMA); 
         assertEquals(root.getString("integrationType"),TestValues.REPOSITORY_INTEGRATION_TYPE);
+        assertEquals(root.getString("repositoryKey"),TestValues.REPOSITORY_KEY);
     }
     
     /**
@@ -105,8 +108,10 @@ public class RepositoryModelTests {
         repository.setName(TestValues.REPOSITORY_NAME);
         repository.setDescription(TestValues.REPOSITORY_DESCRIPTION);
         repository.setUrl(new URI(TestValues.REPOSITORY_URL));
+        repository.setAgreementText(TestValues.REPOSITORY_AGREEMENTTEXT);
         repository.setFormSchema(TestValues.REPOSITORY_FORMSCHEMA);
         repository.setIntegrationType(IntegrationType.of(TestValues.REPOSITORY_INTEGRATION_TYPE));
+        repository.setRepositoryKey(TestValues.REPOSITORY_KEY);
         
         return repository;
     }

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionEventModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionEventModelTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.model;
+
+import java.io.InputStream;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import org.dataconservancy.pass.model.SubmissionEvent.PerformerRole;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.json.JSONObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Model has been annotated with JSON tags. These tests do a simple check to ensure the
+ * Jackson integration is functional and the equals / hashcode functions work
+ * @author Karen Hanson
+ */
+public class SubmissionEventModelTests {
+
+    private DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
+    
+    /**
+     * Simple verification that JSON file can be converted to SubmissionEvent model
+     * @throws Exception
+     */
+    @Test
+    public void testSubmissionEventFromJsonConversion() throws Exception {
+
+        InputStream json = SubmissionEventModelTests.class.getResourceAsStream("/submissionevent.json");
+        ObjectMapper objectMapper = new ObjectMapper();
+        SubmissionEvent submissionEvent = objectMapper.readValue(json, SubmissionEvent.class);
+        
+        assertEquals(TestValues.SUBMISSIONEVENT_ID, submissionEvent.getId().toString());
+        assertEquals(TestValues.USER_ID_1, submissionEvent.getPerformedBy().toString());
+        assertEquals(TestValues.SUBMISSIONEVENT_PERFORMED_DATE_STR, dateFormatter.print(submissionEvent.getPerformedDate()));
+        assertEquals(TestValues.SUBMISSIONEVENT_PERFORMER_ROLE, submissionEvent.getPerformerRole().toString());
+        assertEquals(TestValues.SUBMISSION_ID_1, submissionEvent.getSubmission().toString());
+        assertEquals(TestValues.SUBMISSIONEVENT_EVENT_TYPE, submissionEvent.getEventType().toString());
+        assertEquals(TestValues.SUBMISSIONEVENT_COMMENT, submissionEvent.getComment().toString());
+        assertEquals(TestValues.SUBMISSIONEVENT_LINK, submissionEvent.getLink().toString());
+        
+    }
+
+    /**
+     * Simple verification that SubmissionEvent model can be converted to JSON
+     * @throws Exception
+     */
+    @Test
+    public void testSubmissionEventToJsonConversion() throws Exception {
+
+        SubmissionEvent submissionEvent = createSubmissionEvent();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonSubmissionEvent = objectMapper.writeValueAsString(submissionEvent);
+
+        JSONObject root = new JSONObject(jsonSubmissionEvent);
+
+        assertEquals(root.getString("@id"),TestValues.SUBMISSIONEVENT_ID);
+        assertEquals(root.getString("@type"),"SubmissionEvent");
+        assertEquals(root.getString("eventType"),TestValues.SUBMISSIONEVENT_EVENT_TYPE);
+        assertEquals(root.getString("performedDate"),TestValues.SUBMISSIONEVENT_PERFORMED_DATE_STR);    
+        assertEquals(root.getString("performedBy"),TestValues.USER_ID_1);
+        assertEquals(root.getString("performerRole"),TestValues.SUBMISSIONEVENT_PERFORMER_ROLE);
+        assertEquals(root.getString("submission"),TestValues.SUBMISSION_ID_1);
+        assertEquals(root.getString("comment"),TestValues.SUBMISSIONEVENT_COMMENT);
+        assertEquals(root.getString("link"),TestValues.SUBMISSIONEVENT_LINK);    
+    }
+    
+    /**
+     * Creates two identical SubmissionEvents and checks the equals and hashcodes match. 
+     * Modifies one field on one of the SubmissionEvents and verifies they no longer are 
+     * equal or have matching hashcodes.
+     * @throws Exception
+     */
+    @Test
+    public void testSubmissionEqualsAndHashCode() throws Exception {
+
+        SubmissionEvent submissionEvent1 = createSubmissionEvent();
+        SubmissionEvent submissionEvent2 = createSubmissionEvent();
+        
+        assertEquals(submissionEvent1,submissionEvent2);
+        submissionEvent1.setPerformerRole(SubmissionEvent.PerformerRole.SUBMITTER);
+        assertTrue(!submissionEvent1.equals(submissionEvent2));
+        
+        assertTrue(submissionEvent1.hashCode()!=submissionEvent2.hashCode());
+        submissionEvent1 = submissionEvent2;
+        assertEquals(submissionEvent1.hashCode(),submissionEvent2.hashCode());
+        
+    }
+    
+    private SubmissionEvent createSubmissionEvent() throws Exception {
+        SubmissionEvent submissionEvent = new SubmissionEvent();
+        submissionEvent.setId(new URI(TestValues.SUBMISSIONEVENT_ID));
+        submissionEvent.setEventType(SubmissionEvent.EventType.of(TestValues.SUBMISSIONEVENT_EVENT_TYPE));
+        DateTime dt = dateFormatter.parseDateTime(TestValues.SUBMISSIONEVENT_PERFORMED_DATE_STR);
+        submissionEvent.setPerformedDate(dt);
+        submissionEvent.setPerformedBy(new URI(TestValues.USER_ID_1));
+        submissionEvent.setPerformerRole(PerformerRole.PREPARER);
+        submissionEvent.setSubmission(new URI(TestValues.SUBMISSION_ID_1));
+        submissionEvent.setComment(TestValues.SUBMISSIONEVENT_COMMENT);
+        submissionEvent.setLink(new URI(TestValues.SUBMISSIONEVENT_LINK));
+        
+        return submissionEvent;
+    }
+    
+}

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
-import org.dataconservancy.pass.model.Submission.AggregatedDepositStatus;
+import org.dataconservancy.pass.model.Submission.Source;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -58,14 +59,16 @@ public class SubmissionModelTests {
         assertEquals(TestValues.SUBMISSION_ID_1, submission.getId().toString());
         assertEquals(TestValues.SUBMISSION_METADATA, submission.getMetadata());
         assertEquals(TestValues.SUBMISSION_SUBMITTED, submission.getSubmitted());
-        assertEquals(TestValues.SUBMISSION_STATUS, submission.getAggregatedDepositStatus().toString());
+        assertEquals(TestValues.SUBMISSION_STATUS, submission.getSubmissionStatus().toString());
         assertEquals(TestValues.PUBLICATION_ID_1, submission.getPublication().toString());
-        assertEquals(TestValues.USER_ID_1, submission.getUser().toString());
+        assertEquals(TestValues.USER_ID_1, submission.getSubmitter().toString());
+        assertEquals(TestValues.USER_ID_2, submission.getPreparers().get(0).toString());
         assertEquals(TestValues.REPOSITORY_ID_1, submission.getRepositories().get(0).toString());
         assertEquals(TestValues.REPOSITORY_ID_2, submission.getRepositories().get(1).toString());
         assertEquals(TestValues.GRANT_ID_1, submission.getGrants().get(0).toString());
         assertEquals(TestValues.GRANT_ID_2, submission.getGrants().get(1).toString());
         assertEquals(TestValues.SUBMISSION_DATE_STR, dateFormatter.print(submission.getSubmittedDate()));
+        assertEquals(TestValues.SUBMISSION_SOURCE, submission.getSource().toString());
     }
 
     /**
@@ -83,9 +86,10 @@ public class SubmissionModelTests {
 
         assertEquals(root.getString("@id"),TestValues.SUBMISSION_ID_1);
         assertEquals(root.getString("@type"),"Submission");
-        assertEquals(root.getString("aggregatedDepositStatus"),TestValues.SUBMISSION_STATUS);
+        assertEquals(root.getString("submissionStatus"),TestValues.SUBMISSION_STATUS);
         assertEquals(root.getString("publication"),TestValues.PUBLICATION_ID_1);
-        assertEquals(root.getString("user"),TestValues.USER_ID_1);
+        assertEquals(root.getString("submitter"),TestValues.USER_ID_1);
+        assertEquals(root.getJSONArray("preparers").get(0),TestValues.USER_ID_2);
         assertEquals(root.getBoolean("submitted"),TestValues.SUBMISSION_SUBMITTED);
         assertEquals(root.getString("metadata"),TestValues.SUBMISSION_METADATA);
         assertEquals(root.getJSONArray("repositories").get(0),TestValues.REPOSITORY_ID_1);
@@ -93,6 +97,7 @@ public class SubmissionModelTests {
         assertEquals(root.getJSONArray("grants").get(0),TestValues.GRANT_ID_1);
         assertEquals(root.getJSONArray("grants").get(1),TestValues.GRANT_ID_2);
         assertEquals(root.getString("submittedDate"),TestValues.SUBMISSION_DATE_STR);    
+        assertEquals(root.getString("source"), TestValues.SUBMISSION_SOURCE);
     }
     
     /**
@@ -108,7 +113,7 @@ public class SubmissionModelTests {
         Submission submission2 = createSubmission();
         
         assertEquals(submission1,submission2);
-        submission1.setAggregatedDepositStatus(Submission.AggregatedDepositStatus.ACCEPTED);
+        submission1.setSubmissionStatus(Submission.SubmissionStatus.ACCEPTED);
         assertTrue(!submission1.equals(submission2));
         
         assertTrue(submission1.hashCode()!=submission2.hashCode());
@@ -120,11 +125,16 @@ public class SubmissionModelTests {
     private Submission createSubmission() throws Exception {
         Submission submission = new Submission();
         submission.setId(new URI(TestValues.SUBMISSION_ID_1));
-        submission.setAggregatedDepositStatus(AggregatedDepositStatus.of(TestValues.SUBMISSION_STATUS));
+        submission.setSubmissionStatus(SubmissionStatus.of(TestValues.SUBMISSION_STATUS));
         submission.setMetadata(TestValues.SUBMISSION_METADATA);
         submission.setSubmitted(TestValues.SUBMISSION_SUBMITTED);
         submission.setPublication(new URI(TestValues.PUBLICATION_ID_1));
-        submission.setUser(new URI(TestValues.USER_ID_1));
+        submission.setSubmitter(new URI(TestValues.USER_ID_1));
+        submission.setSource(Source.PASS);
+        
+        List<URI> preparers = new ArrayList<URI>();
+        preparers.add(new URI(TestValues.USER_ID_2));
+        submission.setPreparers(preparers);
         
         List<URI> repositories = new ArrayList<URI>();
         repositories.add(new URI(TestValues.REPOSITORY_ID_1));

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-test-data</artifactId>
   <name>PASS Test Data</name>

--- a/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
+++ b/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
@@ -40,6 +40,7 @@ public class TestValues {
     public static final String REPOSITORYCOPY_ID_1 = "https://example.org/fedora/repositoryCopies/1";
     public static final String SUBMISSION_ID_1 = "https://example.org/fedora/submissions/1";
     public static final String SUBMISSION_ID_2 = "https://example.org/fedora/submissions/2";
+    public static final String SUBMISSIONEVENT_ID = "https://example.org/fedora/submissionEvents/1";
     public static final String USER_ID_1 = "https://example.org/fedora/users/1";
     public static final String USER_ID_2 = "https://example.org/fedora/users/2";
     public static final String USER_ID_3 = "https://example.org/fedora/users/3";
@@ -91,10 +92,12 @@ public class TestValues {
 
     public static final String REPOSITORY_NAME = "Repository A";
     public static final String REPOSITORY_DESCRIPTION = "An OA repository run by funder A";
+    public static final String REPOSITORY_AGREEMENTTEXT = "I agree to the repository deposit agreement";
     public static final String REPOSITORY_URL = "https://repo-example.org/";
     //TODO: verify format of formSchema field
     public static final String REPOSITORY_FORMSCHEMA = "{\"customFieldName\": \"String\"}";
     public static final String REPOSITORY_INTEGRATION_TYPE = "web-link";
+    public static final String REPOSITORY_KEY = "nih-repository";
     
     public static final String REPOSITORYCOPY_STATUS = "accepted";
     public static final String REPOSITORYCOPY_EXTERNALID_1 = "PMC12345";
@@ -103,10 +106,16 @@ public class TestValues {
     
     public static final String SUBMISSION_STATUS = "in-progress";
     public static final String SUBMISSION_DATE_STR = "2018-01-05T12:12:12.000Z";
-    public static final String SUBMISSION_SOURCE = "other";
+    public static final String SUBMISSION_SOURCE = "pass";
     public static final Boolean SUBMISSION_SUBMITTED = true;
     public static final String SUBMISSION_METADATA = "{\"customFieldName\": \"value\"}";
 
+    public static final String SUBMISSIONEVENT_EVENT_TYPE = "approval-requested";
+    public static final String SUBMISSIONEVENT_PERFORMED_DATE_STR = "2018-01-06T12:12:12.000Z";
+    public static final String SUBMISSIONEVENT_PERFORMER_ROLE = "preparer";
+    public static final String SUBMISSIONEVENT_COMMENT = "Does this look OK?";
+    public static final String SUBMISSIONEVENT_LINK = "https://example.org/ember/path/to/submission";
+    
     public static final String USER_NAME = "am12345";
     public static final String USER_FIRST_NAME = "June";
     public static final String USER_MIDDLE_NAME = "Marie";

--- a/pass-test-data/src/main/resources/repository.json
+++ b/pass-test-data/src/main/resources/repository.json
@@ -2,9 +2,11 @@
 	"@id": "https://example.org/fedora/repositories/1",
 	"@type": "Repository",
 	"name": "Repository A",
+	"agreementText": "I agree to the repository deposit agreement",
 	"description": "An OA repository run by funder A",
 	"url": "https://repo-example.org/",
 	"formSchema":"{\"customFieldName\": \"String\"}",
-	"integrationType":"web-link"
+	"integrationType":"web-link",
+	"repositoryKey":"nih-repository"
 }
 	

--- a/pass-test-data/src/main/resources/submission.json
+++ b/pass-test-data/src/main/resources/submission.json
@@ -1,14 +1,15 @@
 {
 	"@id": "https://example.org/fedora/submissions/1",
 	"@type": "Submission",
-	"aggregatedDepositStatus": "in-progress",
+	"submissionStatus": "in-progress",
 	"publication": "https://example.org/fedora/publications/1",
-	"user": "https://example.org/fedora/users/1",
+	"submitter": "https://example.org/fedora/users/1",
+	"preparers": ["https://example.org/fedora/users/2"],
 	"repositories": ["https://example.org/fedora/repositories/1","https://example.org/fedora/repositories/2"],
 	"grants": ["https://example.org/fedora/grants/1","https://example.org/fedora/grants/2"],
 	"submitted": true,
 	"submittedDate": "2018-01-05T12:12:12.000Z",
 	"metadata": "{\"customFieldName\": \"value\"}",
-	"source": "other"
+	"source": "pass"
 }
 	

--- a/pass-test-data/src/main/resources/submissionevent.json
+++ b/pass-test-data/src/main/resources/submissionevent.json
@@ -1,0 +1,12 @@
+{
+	"@id": "https://example.org/fedora/submissionEvents/1",
+	"@type": "SubmissionEvent",
+	"eventType": "approval-requested",
+	"performedDate": "2018-01-06T12:12:12.000Z",
+	"performedBy": "https://example.org/fedora/users/1",
+	"performerRole": "preparer",
+	"submission": "https://example.org/fedora/submissions/1",
+	"comment": "Does this look OK?",
+	"link":"https://example.org/ember/path/to/submission"
+}
+	

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
-  <version>0.3.4-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   
   <name>PASS Client Tool</name>
   


### PR DESCRIPTION
Updates model to reflect changes in model version 3.0, the focus of which is to support a proxy preparer for a Submission. Specifically:
* Adds the `SubmissionEvents` model object
* Changes `Submission.user` to `Submission.submitter`
* Adds `Submission.preparers` and `Submission.submissionStatus`, and defines possible status values
* Removes `Submission.aggregatedDepositStatus`
* Adds `Repository.agreementText`
* Points integration tests to new context document, version 3.0 since a new model object is added and uses updated `oapass/indexer` and `oapass/fcrepo` images.
* Adds integration test to verify that a `mailto:` URI can be used in the `Submission.submitter` field.
* Increments version to `0.4.0-SNAPSHOT`

Closes #47 