### PR TITLE
Add Repository Iterator/Crawler to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ URI grantUri = client.findByAttribute(Grant.class, "awardNumber", awardNumber);
 ```
 The Java docs provide more information about this functionality.
 
+### Crawling/iterating the repository.
+
+Use `org.dataconservancy.pass.client.fedora.RepositoryCrawler`.  It iterates resources in the repository, and invokes a provided `Consumer<URI>` for each resource URI encountered.  Additionally, resources can be ignored (not sent to the consumer, but their children still recursed), or skipped entirely (thus preventing recursion to their children).  `RepositoryCrawler.Ignore` and `RepositoryCrawler.Skip` classes have useful predicates for skipping or ignoring resources.
+
+For example, to iterate ONLY submission resources (and not binary files that might be children of them), use recursion depth of 1, and ignore the parent `submissions/` container, as it is not a `Submission`:
+
+    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_ROOT;
+    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.depth;
+    ...
+     
+    RepositoryCrawler crawler = new RepositoryCrawler();
+    int numVisited = crawler.visit("http://localhost:8080/fcrepo/rest/submissions/", myConsumer, IGNORE_ROOT, depth(1));
+    
+As another example, to iterate ALL pass entities, ignoring ACLs,  ignoring parent containers, and ignoring children of PASS entities (like binary files POSTed to submissions), start with the repository root, to a depth of 2, and ignore containers:
+
+    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_CONTAINERS;
+    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.SKIP_ACLS;
+    ...
+    
+    RepositoryCrawler crawler = new RepositoryCrawler();
+    int numVisited = crawler.visit(URI.create(FedoraConfig.getBaseUrl()), myConsumer, IGNORE_CONTAINERS,
+                depth(2).or(SKIP_ACLS));
+
+
 ### Configuration
 Configuration may be provided via system properties, or environment variables.  System properties are case-sensitive and separated by periods, as per Java conventions.
 Environment variables should be uppercase and separated by underscores, as per OS conventions.  For example, the fedora user may be provided by 

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
@@ -36,6 +36,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import org.dataconservancy.pass.client.fedora.FedoraConfig;
 import org.junit.After;
@@ -290,6 +296,18 @@ public abstract class ClientITBase {
             }
         }
         throw new RuntimeException("Failed executing task", caught);
+    }
+    
+    static CloseableHttpClient getHttpClient() {
+        final CredentialsProvider provider = new BasicCredentialsProvider();
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(FedoraConfig.getUserName(),
+                FedoraConfig.getPassword());
+        provider.setCredentials(AuthScope.ANY, credentials);
+
+        return HttpClientBuilder.create()
+                .setDefaultCredentialsProvider(provider)
+                .build();
+
     }
 
 }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/DeleteResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/DeleteResourceIT.java
@@ -20,17 +20,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 
-import org.dataconservancy.pass.client.fedora.FedoraConfig;
-
 import org.apache.http.HttpStatus;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 
@@ -63,17 +56,5 @@ public class DeleteResourceIT extends ClientITBase {
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    static CloseableHttpClient getHttpClient() {
-        final CredentialsProvider provider = new BasicCredentialsProvider();
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(FedoraConfig.getUserName(),
-                FedoraConfig.getPassword());
-        provider.setCredentials(AuthScope.ANY, credentials);
-
-        return HttpClientBuilder.create()
-                .setDefaultCredentialsProvider(provider)
-                .build();
-
     }
 }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/RepositoryCrawlerIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/RepositoryCrawlerIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.integration;
+
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_CONTAINERS;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.SKIP_ACLS;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.depth;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.client.fedora.FedoraConfig;
+import org.dataconservancy.pass.client.fedora.RepositoryCrawler;
+import org.dataconservancy.pass.model.Submission;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Test;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class RepositoryCrawlerIT extends ClientITBase {
+
+    final CloseableHttpClient http = getHttpClient();
+
+    // We just want to see if this works with Fedora at all
+    @Test
+    public void crawlWorksWithFedoraTest() throws Exception {
+        final RepositoryCrawler crawler = new RepositoryCrawler();
+
+        final int initialCount = crawler.visit(URI.create(FedoraConfig.getBaseUrl()),
+                u -> {
+                },
+                IGNORE_CONTAINERS,
+                depth(2).or(SKIP_ACLS));
+
+        final PassClient client = PassClientFactory.getPassClient();
+
+        final URI submission = client.createResource(new Submission());
+
+        try (CloseableHttpResponse response = http.execute(new HttpPost(submission))) {
+            assertNotNull(response.getFirstHeader("Location"));
+        }
+
+        final List<URI> found = new ArrayList<>();
+        final int afterCount = crawler.visit(URI.create(FedoraConfig.getBaseUrl()), found::add, IGNORE_CONTAINERS,
+                depth(2).or(SKIP_ACLS));
+        assertEquals(1, afterCount - initialCount);
+        assertTrue(found.contains(submission));
+    }
+
+}

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -87,7 +87,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
-    </dependency>    
+    </dependency>   
+    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency> 
     
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FcrepoLister.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/FcrepoLister.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.fedora;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoClient.FcrepoClientBuilder;
+import org.fcrepo.client.FcrepoResponse;
+
+/**
+ * Lists children of a given container.
+ * <p>
+ * Uses n-triples for streaming large results
+ * </p>
+ *
+ * @author apb@jhu.edu
+ */
+class FcrepoLister implements Lister {
+
+    FcrepoClient client = new FcrepoClientBuilder().credentials(FedoraConfig.getUserName(), FedoraConfig
+            .getPassword()).build();
+
+    static final URI PREFER_CONTAINMENT = URI.create("http://www.w3.org/ns/ldp#PreferContainment");
+
+    static final Pattern childPattern = Pattern.compile(
+            ".+?\\s+<http://www.w3.org/ns/ldp#contains>\\s+<(.+?)>.+?");
+
+    @Override
+    public List<URI> getChildren(URI resource) {
+        try (final FcrepoResponse response = client.get(resource)
+                .accept("application/n-triples")
+                .preferRepresentation(asList(PREFER_CONTAINMENT),
+                        emptyList()).perform()) {
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getBody(), UTF_8))) {
+
+                final List<URI> children = new ArrayList<>();
+
+                for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                    final Matcher aclFinder = childPattern.matcher(line);
+                    if (aclFinder.matches()) {
+                        children.add(URI.create(aclFinder.group(1)));
+                    }
+                }
+
+                return children;
+            }
+
+        } catch (final Exception e) {
+            throw new RuntimeException("Error getting children of " + resource, e);
+        }
+    }
+}

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/Lister.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/Lister.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.fedora;
+
+import java.net.URI;
+import java.util.Collection;
+
+/**
+ * List children of a given container.
+ *
+ * @author apb@jhu.edu
+ */
+interface Lister {
+
+    /**
+     * List children of a given container.
+     *
+     * @param container URI of the container.
+     * @return A collection of URIs of children.
+     */
+    Collection<URI> getChildren(URI container);
+}

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/RepositoryCrawler.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/fedora/RepositoryCrawler.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.fedora;
+
+import static java.util.Collections.emptyList;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Crawl/walk through a hierarchy of containers in a repository.
+ * <p>
+ * Given a URI of an LDP container, this class will visit all its children, their childrens children, etc up to a
+ * provided depth and invoke given {@link Consumer}. It is designed to handle an arbitrary large number of resources.
+ * </p>
+ *
+ * @author apb@jhu.edu
+ */
+public class RepositoryCrawler {
+
+    Lister repo = new FcrepoLister();
+
+    /**
+     * Visit a container and its children.
+     * <p>
+     * Invokes a supplied visitor {@link consumer} for every resource underneath a repository container, potentially
+     * ignoring individual resources, or skipping trees or limiting recursion depth respectively.
+     * </p>
+     * <p>
+     * Some examples:
+     * <ul>
+     * <li>Process all submissions, but <em>not</em> binaries POSTed to submissions, and <em>not</em> the submissions
+     * container itself:
+     * <code>visit("https://pass.local/fcepo/rest/submissions/", consumer, IGNORE_ROOT, depth(1));</code></li>
+     * <li>Process all PASS resources, skipping ACLs and top-level containers:
+     * <code>visit("https://pass.local/fcepo/rest/", consumer, IGNORE_CONTAINERS, depth(2).or(SKIP_ACLS));</code>
+     * </ul>
+     * </p>
+     *
+     * @param resource URI of a resource to visit. If the value ends in <code>/*</code>, the crawler will <em>not</em>
+     *        consume the provided container itself, but <em>will</em> consume its children.
+     * @param visitor For every resource visited, it will invoke the consumer with the URI of the current resource.
+     * @param ignore Predicate which, when true, will cause a given resource to be ignored; it will not be sent to the
+     *        visitor, but recursion will still continue to its children. A primary use case is ignoring a container
+     *        resource, but processing its children. See also {@link Ignore}. To ignore none, use
+     *        {@link Ignore#IGNORE_NONE}. If combining multiple predicates, use "or" (i.e. "if one says ignore,
+     *        ignore").
+     * @param skip Predicate which, when true, tells the crawler to stop crawling at that resource, and not visit its
+     *        children. To process every resource without stopping at any, use {@link Skip#SKIP_NONE}. See also
+     *        {@link Skip}. If combining multiple predicates, use "or" (i.e. "if one says stop, stop").
+     * @return the number of resources visited.
+     */
+    public int visit(final URI resource, final Consumer<URI> visitor, Predicate<State> ignore,
+            Predicate<State> skip) {
+        return _visit(resource, visitor, new State(0, null, resource), ignore, skip);
+    }
+
+    private int _visit(final URI resource, final Consumer<URI> visitor, State state, Predicate<State> ignore,
+            Predicate<State> terminal) {
+        int count = 0;
+
+        final Collection<URI> children;
+
+        if (!ignore.test(state)) {
+            // We're not ignoring the resource
+
+            if (!terminal.test(state)) {
+                // If it's not terminal, get its children.
+                children = repo.getChildren(resource);
+            } else {
+                // If it is terminal, do not get its children
+                children = emptyList();
+            }
+
+            // Increment counter and visit.
+            count++;
+            visitor.accept(resource);
+        } else if (!terminal.test(state)) {
+            // Ignored, but not terminal. Get its children.
+            children = repo.getChildren(resource);
+        } else {
+            // Ignored and terminal. Do not visit children,
+            children = emptyList();
+        }
+
+        // Visit children.
+        for (final URI child : children) {
+            count += _visit(child, visitor, new State(state.depth + 1, resource, child), ignore, terminal);
+        }
+
+        return count;
+    }
+
+    /**
+     * Represents repository crawling state.
+     *
+     * @author apb@jhu.edu
+     */
+    public class State {
+
+        /** The depth of recursion */
+        public final int depth;
+
+        /** The parent resource, null for the root of a tree */
+        public final URI parent;
+
+        /** URI of the current resource. */
+        public final URI id;
+
+        /**
+         * Create an immutible crawling state.
+         *
+         * @param depth The depth of recursion
+         * @param parent The parent resource, null for the root of a tree
+         * @param id URI of the current resource.
+         */
+        public State(int depth, URI parent, URI id) {
+            this.depth = depth;
+            this.parent = parent;
+            this.id = id;
+        }
+    }
+
+    /**
+     * Useful predicates for indicating resources to skip when crawling.
+     *
+     * @author apb@jhu.edu
+     */
+    public static interface Skip {
+
+        /** Do not skip any resources */
+        public static final Predicate<State> SKIP_NONE = s -> false;
+
+        /** Skip ACLs */
+        public static final Predicate<State> SKIP_ACLS = s -> s.id.toString().matches(".+/acls[/.+?|$]");
+
+        /**
+         * Limit recursion to a given depth.
+         *
+         * @param limit Recursion limit. 0 = no recursion, 1 = descent to children, 2 = descend to the children's
+         *        children, etc.
+         * @return
+         */
+        public static Predicate<State> depth(int limit) {
+            return s -> s.depth >= limit;
+        }
+    }
+
+    /**
+     * Useful predicates for indicating resources to ignore when crawling.
+     *
+     * @author apb@jhu.edu
+     */
+    public static interface Ignore {
+
+        /** Do not ignore any resources */
+        public static final Predicate<State> IGNORE_NONE = s -> false;
+
+        /** Ignore the given container (root of a tree being traversed) */
+        public static final Predicate<State> IGNORE_ROOT = s -> s.parent == null;
+
+        /** Ignore all "top level" containers for PASS entities, such as /submissions, etc */
+        public static final Predicate<State> IGNORE_CONTAINERS = s -> s.id.toString().matches(
+                endWithSlash(FedoraConfig.getBaseUrl()) + "[a-zA-Z]+/*$") ||
+                RepositoryCrawler.endWithSlash(s.id.toString()).equals(
+                        RepositoryCrawler.endWithSlash(FedoraConfig.getBaseUrl()));
+    }
+
+    static String endWithSlash(String uri) {
+        if (uri.endsWith("/")) {
+            return uri;
+        } else {
+            return uri + "/";
+        }
+    }
+}

--- a/pass-data-client/src/test/java/org/dataconservancy/pass/client/fedora/RepositoryCrawlerTest.java
+++ b/pass-data-client/src/test/java/org/dataconservancy/pass/client/fedora/RepositoryCrawlerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.fedora;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.dataconservancy.pass.client.fedora.FedoraConfig.getBaseUrl;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.endWithSlash;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_CONTAINERS;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_NONE;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_ROOT;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.SKIP_ACLS;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.SKIP_NONE;
+import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.depth;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RepositoryCrawlerTest {
+
+    @Mock
+    Lister lister;
+
+    final URI root = URI.create(getBaseUrl());
+
+    final URI l1_acls_container = URI.create(endWithSlash(getBaseUrl()) + "acls/");
+
+    final URI l1_submissions_container = URI.create(endWithSlash(getBaseUrl()) + "submissions/");
+
+    final URI l1_cows_container = URI.create(endWithSlash(getBaseUrl()) + "cows/");
+
+    final Collection<URI> l1_all = asList(l1_acls_container, l1_submissions_container, l1_cows_container);
+
+    final URI l2_acl_1 = randomUri(l1_acls_container);
+
+    final URI l2_acl_2 = randomUri(l1_acls_container);
+
+    final Collection<URI> l2_acls = asList(l2_acl_1, l2_acl_2);
+
+    final URI l2_cow_1 = randomUri(l1_cows_container);
+
+    final URI l2_cow_2 = randomUri(l1_cows_container);
+
+    final Collection<URI> l2_cows = asList(l2_cow_1, l2_cow_2);
+
+    final URI l2_submissions_1 = randomUri(l1_submissions_container);
+
+    final URI l2_submissions_2 = randomUri(l1_submissions_container);
+
+    final Collection<URI> l2_submissions = asList(l2_submissions_1, l2_submissions_2);
+
+    final Collection<URI> l2_all = union(l2_acls, l2_cows, l2_submissions);
+
+    final URI l3_acl_1 = randomUri(l2_acl_1);
+
+    final URI l3_acl_2 = randomUri(l2_acl_2);
+
+    final Collection<URI> l3_acls = asList(l3_acl_1, l3_acl_2);
+
+    final URI l3_submissions_1 = randomUri(l2_submissions_1);
+
+    final URI l3_submissions_2 = randomUri(l2_submissions_2);
+
+    final Collection<URI> l3_aubmissions = asList(l3_submissions_1, l3_submissions_2);
+
+    final Collection<URI> l3_all = union(l3_acls, l3_aubmissions);
+
+    final RepositoryCrawler toTest = new RepositoryCrawler();
+
+    @Before
+    public void wire() {
+        toTest.repo = lister;
+
+        // default - no children
+        when(lister.getChildren(any())).thenReturn(emptyList());
+
+        // Now we define our tree
+        when(lister.getChildren(eq(root))).thenReturn(l1_all);
+        when(lister.getChildren(eq(l1_submissions_container))).thenReturn(l2_submissions);
+        when(lister.getChildren(eq(l1_acls_container))).thenReturn(l2_acls);
+        when(lister.getChildren(eq(l1_cows_container))).thenReturn(l2_cows);
+        when(lister.getChildren(eq(l2_acl_1))).thenReturn(asList(l3_acl_1));
+        when(lister.getChildren(eq(l2_acl_2))).thenReturn(asList(l3_acl_2));
+        when(lister.getChildren(eq(l2_submissions_1))).thenReturn(asList(l3_submissions_1));
+        when(lister.getChildren(eq(l2_submissions_2))).thenReturn(asList(l3_submissions_2));
+    }
+
+    // Verify that zero depth just retrieves one resource, and doesn't fetch children.
+    @Test
+    public void zeroDepthTest() {
+
+        final List<URI> visited = new ArrayList<>();
+        assertEquals(1, toTest.visit(root, visited::add, IGNORE_NONE, depth(0)));
+        assertEquals(1, visited.size());
+        assertEquals(root, visited.get(0));
+        verify(lister, times(0)).getChildren(any());
+    }
+
+    // Verify that we can limit depth
+    @Test
+    public void depthTest() {
+        final List<URI> visited = new ArrayList<>();
+
+        // Root + all on level 1
+        final Collection<URI> upToL1 = union(asList(root), l1_all);
+
+        assertEquals(upToL1.size(), toTest.visit(root, visited::add, IGNORE_NONE, depth(1)));
+        assertEquals(upToL1.size(), visited.size());
+        verify(lister, times(1)).getChildren(any());
+
+        assertTrue(visited.containsAll(upToL1));
+    }
+
+    // Verify that all resources are visited if we start from root
+    @Test
+    public void entireRepositoryTest() {
+        final List<URI> visited = new ArrayList<>();
+
+        final Collection<URI> allResources = union(asList(root), l1_all, l2_all, l3_all);
+
+        assertEquals(allResources.size(), toTest.visit(root, visited::add, IGNORE_NONE, SKIP_NONE));
+        assertEquals(allResources.size(), visited.size());
+    }
+
+    // Verify that ignore IGNORE_ROOT will skip the parent container, and works with depth
+    @Test
+    public void ignoreRootTestWithDepth() {
+        final List<URI> visited = new ArrayList<>();
+
+        assertEquals(l2_submissions.size(), toTest.visit(l1_submissions_container, visited::add,
+                IGNORE_ROOT, depth(1)));
+        assertEquals(l2_submissions.size(), visited.size());
+        assertTrue(visited.containsAll(l2_submissions));
+        assertFalse(visited.contains(l1_submissions_container));
+
+        // Should only list resources of parent container, so one invocation ony;
+        verify(lister, times(1)).getChildren(any());
+    }
+
+    // Verify that IGNORE CONTAINERS will skip top level containers
+    @Test
+    public void skipContainerTestInfiniteDepth() {
+        final List<URI> visited = new ArrayList<>();
+
+        final Collection<URI> allExceptContainers = union(l2_all, l3_all);
+
+        assertEquals(allExceptContainers.size(), toTest.visit(root, visited::add,
+                IGNORE_CONTAINERS,
+                SKIP_NONE));
+        assertEquals(allExceptContainers.size(), visited.size());
+        assertTrue(visited.containsAll(allExceptContainers));
+    }
+
+    @Test
+    public void skipAclsTest() {
+        final List<URI> visited = new ArrayList<>();
+
+        final Collection<URI> allExceptAclsAndContainers = union(l2_cows, l2_submissions, l3_aubmissions);
+
+        assertEquals(allExceptAclsAndContainers.size(), toTest.visit(root, visited::add, IGNORE_CONTAINERS,
+                SKIP_ACLS));
+        assertEquals(allExceptAclsAndContainers.size(), visited.size());
+        assertTrue(visited.containsAll(allExceptAclsAndContainers));
+    }
+
+    @Test
+    public void skipAclsWithDepthTest() {
+        final List<URI> visited = new ArrayList<>();
+
+        final Collection<URI> depth1ExceptAclsAndContainers = union(l2_cows, l2_submissions);
+
+        assertEquals(depth1ExceptAclsAndContainers.size(), toTest.visit(root, visited::add, IGNORE_CONTAINERS,
+                depth(2).or(SKIP_ACLS)));
+        assertEquals(depth1ExceptAclsAndContainers.size(), visited.size());
+        assertTrue(visited.containsAll(depth1ExceptAclsAndContainers));
+    }
+
+    private static URI randomUri(URI base) {
+        return URI.create(endWithSlash(base.toString() + "/a/b/c/" + UUID.randomUUID().toString()));
+    }
+
+    @SafeVarargs
+    private static Collection<URI> union(Collection<URI>... collections) {
+        final Set<URI> members = new HashSet<>();
+        for (final Collection<URI> c : collections) {
+            members.addAll(c);
+        }
+
+        return members;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <jackson.version>2.9.4</jackson.version>
     <fcrepo-java-client.version>0.3.0</fcrepo-java-client.version>
     <logback.version>1.2.3</logback.version>
+    <mockito.version>2.22.0</mockito.version>
     <openpojo.version>0.8.10</openpojo.version>
     <elasticsearch-client.version>6.2.3</elasticsearch-client.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -277,6 +278,13 @@
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>logging-interceptor</artifactId>
         <version>${okhttp.version}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.22.0</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Crawling/iterating the repository.

Use `org.dataconservancy.pass.client.fedora.RepositoryCrawler`.  It iterates resources in the repository, and invokes a provided `Consumer<URI>` for each resource URI encountered.  Additionally, resources can be ignored (not sent to the consumer, but their children still recursed), or skipped entirely (thus preventing recursion to their children).  `RepositoryCrawler.Ignore` and `RepositoryCrawler.Skip` classes have useful predicates for skipping or ignoring resources.

For example, to iterate ONLY submission resources (and not binary files that might be children of them), use recursion depth of 1, and ignore the parent `submissions/` container, as it is not a `Submission`:

    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_ROOT;
    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.depth;
    ...
     
    RepositoryCrawler crawler = new RepositoryCrawler();
    int numVisited = crawler.visit("http://localhost:8080/fcrepo/rest/submissions/", myConsumer, IGNORE_ROOT, depth(1));
    
As another example, to iterate ALL pass entities, ignoring ACLs,  ignoring parent containers, and ignoring children of PASS entities (like binary files POSTed to submissions), start with the repository root, to a depth of 2, and ignore containers:

    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Ignore.IGNORE_CONTAINERS;
    import static org.dataconservancy.pass.client.fedora.RepositoryCrawler.Skip.SKIP_ACLS;
    ...
    
    RepositoryCrawler crawler = new RepositoryCrawler();
    int numVisited = crawler.visit(URI.create(FedoraConfig.getBaseUrl()), myConsumer, IGNORE_CONTAINERS,
                depth(2).or(SKIP_ACLS));

Resolves #51 