### PR TITLE
Adds a shaded artifact supporting model 2.3

### DIFF
--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -210,9 +210,8 @@
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
-      <artifactId>pass-client-shaded</artifactId>
+      <artifactId>pass-client-shaded-v2_3</artifactId>
       <version>${project.version}</version>
-      <classifier>v2_3</classifier>
       <scope>test</scope>
     </dependency>
 

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -207,6 +207,14 @@
       <artifactId>pass-data-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+    
+    <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-client-shaded</artifactId>
+      <version>${project.version}</version>
+      <classifier>v2_3</classifier>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.unitils</groupId>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ShadedClientIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ShadedClientIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.client.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.client.PassClientFactory;
+import org.dataconservancy.pass.model.Submission;
+
+import org.junit.Test;
+
+/**
+ * Verifies that the shaded client can function beside the current client
+ *
+ * @author apb@jhu.edu
+ */
+public class ShadedClientIT extends ClientITBase {
+
+    @Test
+    public void conversionTest() {
+        final PassClient newClient = PassClientFactory.getPassClient();
+        final org.dataconservancy.pass.v2_3.client.PassClient oldClient =
+                org.dataconservancy.pass.v2_3.client.PassClientFactory.getPassClient();
+
+        org.dataconservancy.pass.v2_3.model.Submission older = new org.dataconservancy.pass.v2_3.model.Submission();
+
+        // Now persist a resource the old way;
+
+        // First, we use an incompatible field (present in 2.x absent in 3.x):
+        older.setUser(URI.create("http://example.org"));
+
+        // Now, we use a compatible/unchanged field (same in 2.x and 3.x)
+        older.setMetadata("boo!");
+
+        // Persist the old object
+        final URI submissionUri = oldClient.createResource(older);
+        createdUris.put(submissionUri, Submission.class);
+
+        // verify that the old client can read it.
+        older = oldClient.readResource(submissionUri, org.dataconservancy.pass.v2_3.model.Submission.class);
+
+        // Now, read the data with the new client
+        final Submission newer = newClient.readResource(submissionUri, Submission.class);
+
+        // The compatible/unchanged field should be the same
+        assertEquals(older.getMetadata(), newer.getMetadata());
+
+        // Now, set the new field "submitter" to the old field "user"
+        newer.setSubmitter(older.getUser());
+
+        // Save!
+        final Submission updated = newClient.updateAndReadResource(newer, Submission.class);
+
+        // Now, make sure the migrated field is now the same, and the compatible/unchanged fields are the same
+        assertEquals(older.getUser(), updated.getSubmitter());
+        assertEquals(older.getMetadata(), updated.getMetadata());
+    }
+
+}

--- a/pass-client-shaded-v2_3/dependency-reduced-pom.xml
+++ b/pass-client-shaded-v2_3/dependency-reduced-pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>pass-client</artifactId>
+    <groupId>org.dataconservancy.pass</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>pass-client-shaded-v2_3</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <shadedPattern>org.dataconservancy.pass.v2_3</shadedPattern>
+                  <pattern>org.dataconservancy.pass</pattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer />
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>org/dataconservancy/pass/**</includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pass-client-shaded-v2_3/pom.xml
+++ b/pass-client-shaded-v2_3/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>pass-client</artifactId>
     <version>0.4.0-SNAPSHOT</version>
   </parent>
-  <artifactId>pass-client-shaded</artifactId>
+  <artifactId>pass-client-shaded-v2_3</artifactId>
   <packaging>jar</packaging>
   <build>
     <plugins>
@@ -21,8 +21,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>v2_3</shadedClassifierName>
               <relocations>
                 <relocation>
                   <shadedPattern>org.dataconservancy.pass.v2_3</shadedPattern>

--- a/pass-client-shaded/pom.xml
+++ b/pass-client-shaded/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.dataconservancy.pass</groupId>
+    <artifactId>pass-client</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pass-client-shaded</artifactId>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>v2_3</shadedClassifierName>
+              <relocations>
+                <relocation>
+                  <shadedPattern>org.dataconservancy.pass.v2_3</shadedPattern>
+                  <pattern>org.dataconservancy.pass</pattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>org/dataconservancy/pass/**</includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-data-client</artifactId>
+      <version>0.3.4-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -92,6 +92,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency> 
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>pass-client-util</module>
     <module>pass-client-integration</module>
     <module>pass-test-data</module>
+    <module>pass-client-shaded</module>
   </modules>
 
   <profiles>
@@ -305,5 +306,31 @@
     </snapshotRepository>
 
   </distributionManagement>
+  
+  <repositories>
+    <repository>
+      <id>oss</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>dc.public.snapshots</id>
+      <name>Data Conservancy Public Maven Repository (snapshots)</name>
+      <layout>default</layout>
+      <url>http://maven.dataconservancy.org/public/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <module>pass-client-util</module>
     <module>pass-client-integration</module>
     <module>pass-test-data</module>
-    <module>pass-client-shaded</module>
+    <module>pass-client-shaded-v2_3</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
The shaded artifact `pass-client-shaded-v2_3` produces a jar whereby all client classes are prefixed by `org.dataconservancy.pass.v2_3`.  This allows simultaneous usage of the current model 3.x and model 2.3 in client code, supporting use cases that relate to converting/migrating 2.3 data to 3.x.  

Includes an integration test `ShadedClientIT` that tests and illustrates usage of multiple client versions for creating a 2.3 resource with a 2.3 client, then upgrading it with a 3.0 client.

Resolves #54 