### PR TITLE
Add Submission status calculator

### DIFF
--- a/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
+++ b/pass-client-api/src/main/java/org/dataconservancy/pass/client/PassClient.java
@@ -81,8 +81,7 @@ public interface PassClient {
     public void deleteResource(URI uri);
     
     /**
-     * Retrieves the entity matching the URI provided, populates the  
-     * appropriate Java class with its values.
+     * Retrieves the entity matching the URI provided, populates the appropriate Java class with its values.
      * @param uri
      * @param modelClass
      * @return

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -207,6 +207,12 @@
       <artifactId>pass-data-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.dataconservancy.pass</groupId>
+      <artifactId>pass-status-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/SubmissionStatusServiceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/SubmissionStatusServiceIT.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.integration;
+
+import java.net.URI;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.dataconservancy.pass.client.SubmissionStatusService;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.model.SubmissionEvent.EventType;
+import org.joda.time.DateTime;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for Submission Status Service.
+ * @author Karen Hanson
+ */
+public class SubmissionStatusServiceIT extends ClientITBase {
+
+    //some test URIs 
+    private URI repo1Id;
+    private URI repo2Id;
+    private URI publicationId;
+    
+    @Before
+    public void createDefaultTestData() throws Exception {
+
+        repo1Id = new URI("repository:1");
+        repo2Id = new URI("repository:2");
+        publicationId = new URI("publication:1");
+        
+    }
+    
+    
+    /**
+     * Make sure that if the status is null when the calculateAndUpdateSubmissionStatus is run,
+     * null gets replaced with a value.
+     */
+    @Test
+    public void testSetPreSubmissionStatusWhenNull() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(false);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(null);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of events that will be used to calculate status
+        SubmissionEvent subEvent1 = random(SubmissionEvent.class, 1);
+        subEvent1.setEventType(EventType.APPROVAL_REQUESTED);
+        subEvent1.setPerformedDate(new DateTime(2018, 2, 1, 12, 1, 0, 0));
+        subEvent1.setSubmission(submissionId);
+        URI subEvent1Id = client.createResource(subEvent1);
+        this.createdUris.put(subEvent1Id, SubmissionEvent.class);
+        
+        SubmissionEvent subEvent2 = random(SubmissionEvent.class, 1);
+        subEvent2.setEventType(EventType.CANCELLED);
+        subEvent2.setPerformedDate(new DateTime(2018, 2, 1, 14, 1, 0, 0));
+        subEvent2.setSubmission(submissionId);
+        URI subEvent2Id = client.createResource(subEvent2);
+        this.createdUris.put(subEvent2Id, SubmissionEvent.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(SubmissionEvent.class, "@id", subEvent2Id);
+            assertEquals(subEvent2Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        //check correct value returned
+        assertEquals(SubmissionStatus.CANCELLED, newStatus);
+        
+        //also check database updated
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.CANCELLED, submission.getSubmissionStatus());
+        
+    }
+
+    /**
+     * Make sure that if the status is pre-submission and has a value it does not override status value
+     */
+    @Test
+    public void testDoNotOverridePreSubmissionStatusWhenHasValue() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(false);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(SubmissionStatus.APPROVAL_REQUESTED);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of events that will be used to calculate status
+        SubmissionEvent subEvent1 = random(SubmissionEvent.class, 1);
+        subEvent1.setEventType(EventType.APPROVAL_REQUESTED);
+        subEvent1.setPerformedDate(new DateTime(2018, 2, 1, 12, 1, 0, 0));
+        subEvent1.setSubmission(submissionId);
+        URI subEvent1Id = client.createResource(subEvent1);
+        this.createdUris.put(subEvent1Id, SubmissionEvent.class);
+        
+        SubmissionEvent subEvent2 = random(SubmissionEvent.class, 1);
+        subEvent2.setEventType(EventType.CANCELLED);
+        subEvent2.setPerformedDate(new DateTime(2018, 2, 1, 14, 1, 0, 0));
+        subEvent2.setSubmission(submissionId);
+        URI subEvent2Id = client.createResource(subEvent2);
+        this.createdUris.put(subEvent2Id, SubmissionEvent.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(SubmissionEvent.class, "@id", subEvent2Id);
+            assertEquals(subEvent2Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        //check correct value returned
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED, newStatus);
+        
+        //also check database updated
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED, submission.getSubmissionStatus());
+        
+    }
+
+    
+    /**
+     * Make sure that if the status is pre-submission and has a value it will override the value
+     * if the user set override to true
+     */
+    @Test
+    public void testOverridePreSubmissionStatusWhenSet() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(false);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(SubmissionStatus.APPROVAL_REQUESTED);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of events that will be used to calculate status
+        SubmissionEvent subEvent1 = random(SubmissionEvent.class, 1);
+        subEvent1.setEventType(EventType.APPROVAL_REQUESTED);
+        subEvent1.setPerformedDate(new DateTime(2018, 2, 1, 12, 1, 0, 0));
+        subEvent1.setSubmission(submissionId);
+        URI subEvent1Id = client.createResource(subEvent1);
+        this.createdUris.put(subEvent1Id, SubmissionEvent.class);
+        
+        SubmissionEvent subEvent2 = random(SubmissionEvent.class, 1);
+        subEvent2.setEventType(EventType.CHANGES_REQUESTED);
+        subEvent2.setPerformedDate(new DateTime(2018, 2, 1, 14, 1, 0, 0));
+        subEvent2.setSubmission(submissionId);
+        URI subEvent2Id = client.createResource(subEvent2);
+        this.createdUris.put(subEvent2Id, SubmissionEvent.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(SubmissionEvent.class, "@id", subEvent2Id);
+            assertEquals(subEvent2Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        //this time we set override to true
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(true);
+        //check correct value returned
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED, newStatus);
+        
+        //also check database updated
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED, submission.getSubmissionStatus());
+        
+    }
+    
+
+    
+    /**
+     * Make sure Deposits used in post-submission status calc
+     */
+    @Test
+    public void testPostSubmissionStatusFromDeposits() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(true);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(SubmissionStatus.APPROVAL_REQUESTED);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of deposits that will be used to calculate status
+        Deposit deposit1 = random(Deposit.class, 1);
+        deposit1.setDepositStatus(DepositStatus.ACCEPTED);
+        deposit1.setRepository(repo1Id);
+        deposit1.setSubmission(submissionId);
+        URI deposit1Id = client.createResource(deposit1);
+        this.createdUris.put(deposit1Id, Deposit.class);
+        
+        Deposit deposit2 = random(Deposit.class, 1);
+        deposit2.setDepositStatus(DepositStatus.FAILED);
+        deposit2.setRepository(repo2Id);
+        deposit2.setSubmission(submissionId);
+        URI deposit2Id = client.createResource(deposit1);
+        this.createdUris.put(deposit2Id, Deposit.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(Deposit.class, "@id", deposit2Id);
+            assertEquals(deposit2Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        //this time we set override to true
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        //check correct value returned
+        assertEquals(SubmissionStatus.SUBMITTED, newStatus);
+        
+        //also check database updated
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.SUBMITTED, submission.getSubmissionStatus());
+        
+    }
+
+    
+    /**
+     * Make sure RepositoryCopies used in post-submission status calc
+     */
+    @Test
+    public void testPostSubmissionStatusFromRepositoryCopies() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(true);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of deposits that will be used to calculate status
+        Deposit deposit1 = random(Deposit.class, 1);
+        deposit1.setDepositStatus(DepositStatus.ACCEPTED);
+        deposit1.setRepository(repo1Id);
+        deposit1.setSubmission(submissionId);
+        URI deposit1Id = client.createResource(deposit1);
+        this.createdUris.put(deposit1Id, Deposit.class);
+        
+        //using rejected status, going to override this with the repocopy
+        Deposit deposit2 = random(Deposit.class, 1);
+        deposit2.setDepositStatus(DepositStatus.REJECTED);
+        deposit2.setRepository(repo2Id);
+        deposit2.setSubmission(submissionId);
+        URI deposit2Id = client.createResource(deposit1);
+        this.createdUris.put(deposit2Id, Deposit.class);
+        
+        // completed repocopy for repo1
+        RepositoryCopy repoCopy1 = random(RepositoryCopy.class, 1);
+        repoCopy1.setPublication(publicationId);
+        repoCopy1.setRepository(repo1Id);
+        repoCopy1.setCopyStatus(CopyStatus.COMPLETE);
+        URI repoCopy1Id = client.createResource(repoCopy1);
+        this.createdUris.put(repoCopy1Id, RepositoryCopy.class);
+
+        //completed repocopy fro repo2
+        RepositoryCopy repoCopy2 = random(RepositoryCopy.class, 1);
+        repoCopy2.setPublication(publicationId);
+        repoCopy2.setRepository(repo2Id);
+        repoCopy2.setCopyStatus(CopyStatus.COMPLETE);
+        URI repoCopy2Id = client.createResource(repoCopy2);
+        this.createdUris.put(repoCopy2Id, RepositoryCopy.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(RepositoryCopy.class, "@id", repoCopy2Id);
+            assertEquals(repoCopy2Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        //this time we won't update Submission record, just return the value
+        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        assertEquals(SubmissionStatus.COMPLETE, newStatus);
+        
+        //also check database was not updated with the new value
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.SUBMITTED, submission.getSubmissionStatus());
+        
+    }
+
+    
+    /**
+     * Make sure both Deposits and RepositoryCopies are used in post-submission status calc.
+     * This time, we want to make sure that the item NEEDS ATTENTION if one Deposit fails
+     * and the other succeeds, even though there is a complete RepositoryCopy for one.
+     */
+    @Test
+    public void testPostSubmissionStatusFromDepositsAndRepoCopies() {
+        
+        // create a random Submission, but add important values for this test
+        Submission submission = random(Submission.class, 1);
+        submission.setSubmitted(true);
+        submission.setRepositories(Arrays.asList(repo1Id, repo2Id));
+        submission.setPublication(publicationId);
+        submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+        URI submissionId = client.createResource(submission);
+        this.createdUris.put(submissionId, Submission.class);
+        
+        // add a couple of deposits that will be used to calculate status
+        Deposit deposit1 = random(Deposit.class, 1);
+        deposit1.setDepositStatus(DepositStatus.ACCEPTED);
+        deposit1.setRepository(repo1Id);
+        deposit1.setSubmission(submissionId);
+        URI deposit1Id = client.createResource(deposit1);
+        this.createdUris.put(deposit1Id, Deposit.class);
+        
+        //using rejected status, going to override this with the repocopy
+        Deposit deposit2 = random(Deposit.class, 1);
+        deposit2.setDepositStatus(DepositStatus.REJECTED);
+        deposit2.setRepository(repo2Id);
+        deposit2.setSubmission(submissionId);
+        URI deposit2Id = client.createResource(deposit2);
+        this.createdUris.put(deposit2Id, Deposit.class);
+
+        //completed repocopy fro repo2
+        RepositoryCopy repoCopy1 = random(RepositoryCopy.class, 1);
+        repoCopy1.setPublication(publicationId);
+        repoCopy1.setRepository(repo1Id);
+        repoCopy1.setCopyStatus(CopyStatus.COMPLETE);
+        URI repoCopy1Id = client.createResource(repoCopy1);
+        this.createdUris.put(repoCopy1Id, RepositoryCopy.class);
+        
+        //wait for index
+        attempt(RETRIES, () -> {
+            final URI uri = client.findByAttribute(RepositoryCopy.class, "@id", repoCopy1Id);
+            assertEquals(repoCopy1Id, uri);
+        }); 
+
+        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION, newStatus);
+        
+        //also check database was not updated with the new value
+        submission = client.readResource(submissionId, Submission.class);
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION, submission.getSubmissionStatus());
+        
+    }
+}

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Submission.java
@@ -115,28 +115,28 @@ public class Submission extends PassEntity {
          * document and complete the Submission.
          */
         @JsonProperty("manuscript-required")
-        MANUSCRIPT_REQUIRED("manuscript-required"),
+        MANUSCRIPT_REQUIRED("manuscript-required", false),
         
         /**
          * A Submission was prepared by a preparer but now needs the submitter to approve and submit it or provide 
          * feedback.
          */        
         @JsonProperty("approval-requested")
-        APPROVAL_REQUESTED("approval-requested"),
+        APPROVAL_REQUESTED("approval-requested", false),
         
         /**
          * A Submission was prepared by a preparer, but on review by the submitter, a change was requested. 
          * The Submission has been handed back to the preparer for editing.
          */
         @JsonProperty("changes-requested")
-        CHANGES_REQUESTED("changes-requested"),
+        CHANGES_REQUESTED("changes-requested", false),
 
         /**
          * A Submission was prepared and then cancelled by the submitter or preparer without being submitted. 
          * No further edits can be made to the Submission.
          */
         @JsonProperty("cancelled")
-        CANCELLED("cancelled"),
+        CANCELLED("cancelled", false),
 
         /**
          * The submit button has been pressed through the UI. From this status forward, the Submission 
@@ -147,21 +147,21 @@ public class Submission extends PassEntity {
          * verify completion of the process in the target Repository.
          */
         @JsonProperty("submitted")
-        SUBMITTED("submitted"),
+        SUBMITTED("submitted", true),
 
         /**
          * Indicates that a User action may be required outside of PASS. The Submission is stalled or 
          * has been rejected by one or more Repository
          */
         @JsonProperty("needs-attention")
-        NEEDS_ATTENTION("needs-attention"),
+        NEEDS_ATTENTION("needs-attention", true),
 
         /**
          * The target repositories have all received a copy of the Submission, and have indicated that 
          * the Submission was successful.
          */
         @JsonProperty("complete")
-        COMPLETE("complete");
+        COMPLETE("complete", true);
 
         private static final Map<String, SubmissionStatus> map = new HashMap<>(values().length, 1);  
         static {
@@ -170,8 +170,11 @@ public class Submission extends PassEntity {
         
         private String value;
         
-        private SubmissionStatus(String value){
+        private boolean submitted;
+        
+        private SubmissionStatus(String value, boolean submitted){
             this.value = value;
+            this.submitted = submitted;
         }
         
         public static SubmissionStatus of(String status) {
@@ -182,6 +185,10 @@ public class Submission extends PassEntity {
             return result;
           }
 
+        public boolean isSubmitted() {
+            return submitted;
+        }
+        
         @Override
         public String toString() {
             return this.value;
@@ -309,9 +316,18 @@ public class Submission extends PassEntity {
     /**
      * @return the submitted
      */
+    public Boolean calculate() {
+        return submitted;
+    }
+
+    
+    /**
+     * @param submitted the submitted to set
+     */
     public Boolean getSubmitted() {
         return submitted;
     }
+
 
     
     /**

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/SubmissionModelTests.java
@@ -35,6 +35,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONObject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -123,6 +124,20 @@ public class SubmissionModelTests {
         submission1 = submission2;
         assertEquals(submission1.hashCode(),submission2.hashCode());
         
+    }
+
+    /**
+     * Verifies that we can use the "submitted" status related to a SubmissionStatus.
+     * @throws Exception
+     */
+    @Test
+    public void testSubmissionStatusSubmitted() throws Exception {
+        assertFalse(SubmissionStatus.APPROVAL_REQUESTED.isSubmitted());
+        assertFalse(SubmissionStatus.CANCELLED.isSubmitted());
+        assertTrue(SubmissionStatus.COMPLETE.isSubmitted());
+        
+        Submission submission = createSubmission();
+        assertTrue(submission.getSubmissionStatus().isSubmitted());
     }
     
     private Submission createSubmission() throws Exception {

--- a/pass-status-service/pom.xml
+++ b/pass-status-service/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.dataconservancy.pass</groupId>
+    <artifactId>pass-client</artifactId>
+    <version>0.4.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>pass-status-service</artifactId>
+  <name>PASS Status Utility</name>
+  <dependencies>
+  	<dependency>
+  	  <groupId>org.dataconservancy.pass</groupId>
+  	  <artifactId>pass-client-api</artifactId>
+      <version>${project.parent.version}</version>
+  	</dependency>
+  	
+  	<dependency>
+  	  <groupId>org.dataconservancy.pass</groupId>
+  	  <artifactId>pass-data-client</artifactId>
+      <version>${project.parent.version}</version>
+  	</dependency>
+  	
+  	<dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    
+    <!-- TESTS -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency> 
+    
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+  </dependencies>
+</project>

--- a/pass-status-service/src/main/java/org/dataconservancy/pass/client/SubmissionStatusService.java
+++ b/pass-status-service/src/main/java/org/dataconservancy/pass/client/SubmissionStatusService.java
@@ -1,0 +1,200 @@
+package org.dataconservancy.pass.client;
+
+import java.net.URI;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.dataconservancy.pass.client.util.SubmissionStatusCalculator;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A service for calculating and updating the `Submission.submissionStatus` value based on data
+ * related to the Submission. By default, there is a division of responsibility in calculating 
+ * this status, with pre-submission statuses being managed by the UI, and post-Submission statuses
+ * being managed by back-end services. For this reason, pre-submission statuses will only be changed
+ * if the starting value is null, or overrideUIStatus is true.
+ * @author Karen Hanson
+ *
+ */
+public class SubmissionStatusService 
+{
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusService.class);
+    
+    private PassClient client;
+    
+    private Submission submission;
+    
+    /**
+     * Initiate service using a Submission object
+     * @param submission
+     */
+    public SubmissionStatusService(Submission submission) { 
+        if (submission==null) {
+            throw new IllegalArgumentException("submission cannot be null");
+        }
+        if (submission.getId()==null) {
+            throw new IllegalArgumentException("No status could be calculated for the Submission as it does not have a `Submission.id`.");  
+        }
+        this.client = PassClientFactory.getPassClient();
+        this.submission = submission;
+    }
+
+
+    /**
+     * Initiate service using a `Submission.id` 
+     * @param submissionId
+     */
+    public SubmissionStatusService(URI submissionId) { 
+        if (submissionId==null) {
+            throw new IllegalArgumentException("submissionId cannot be null");
+        }
+        this.client = PassClientFactory.getPassClient();
+        try {
+            this.submission = client.readResource(submissionId, Submission.class);
+        } catch (Exception ex) {
+            String msg = String.format("Failed to retrieve Submission with ID %s from the database", submissionId);
+            throw new RuntimeException(msg);
+        }
+    }
+    
+    
+    /**
+     * Supports setting a specific client, primarily for testing.
+     * @param submission
+     * @param client
+     */
+    public SubmissionStatusService(Submission submission, PassClient client) {
+        if (submission==null) {
+            throw new IllegalArgumentException("submission cannot be null");
+        }
+        if (client==null) {
+            throw new IllegalArgumentException("client cannot be null");
+        }
+        this.submission = submission;
+        this.client = client;
+    }
+
+    
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@link Submission} provided. 
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for 
+     * {@code submitted} records, and {@link SubmissionEvent}s for unsubmitted records.
+     * @param submission
+     * @return
+     */
+    public SubmissionStatus calculateSubmissionStatus() {
+
+        URI submissionId = submission.getId();
+        boolean submitted = submission.getSubmitted();
+
+        SubmissionStatus fromStatus = submission.getSubmissionStatus();
+        SubmissionStatus toStatus;
+        
+        
+        if (!submitted) {
+            
+            // before submission, we need too look at events for clues about status
+            Set<URI> submissionEventUris = client.findAllByAttribute(SubmissionEvent.class, "submission", submissionId);
+            List<SubmissionEvent> submissionEvents = submissionEventUris.stream()
+                    .map(r -> client.readResource(r, SubmissionEvent.class))
+                    .collect(Collectors.toList());
+            
+            toStatus = SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents);            
+                        
+        } else {
+            
+            Set<URI> depositUris = client.findAllByAttribute(Deposit.class, "submission", submissionId);
+            List<Deposit> deposits = depositUris.stream()
+                                        .map(r -> client.readResource(r, Deposit.class))
+                                        .collect(Collectors.toList());
+            
+            Set<URI> repositoryCopyUris = client.findAllByAttribute(RepositoryCopy.class, "publication", submission.getPublication());
+            List<RepositoryCopy> repositoryCopies = repositoryCopyUris.stream()
+                    .map(r -> client.readResource(r, RepositoryCopy.class))
+                    .collect(Collectors.toList());
+
+            toStatus = SubmissionStatusCalculator.calculatePostSubmissionStatus(submission.getRepositories(), deposits, repositoryCopies);
+            
+        }
+
+        try {
+            SubmissionStatusCalculator.validateStatusChange(submitted, fromStatus, toStatus);
+        } catch (RuntimeException ex) {
+            String msg = String.format("Cannot change status from %s to %s on Submission %s. "
+                                        + "The following explaination was provided: %s", fromStatus, toStatus, submissionId, ex.getMessage());
+            throw new RuntimeException(msg);
+        }
+        
+        return toStatus;
+        
+    }
+    
+
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@link Submission} provided. 
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for 
+     * {@code submitted} records, and {@link SubmissionEvent}s for unsubmitted records then updates 
+     * the status as appropriate. <br><br>
+     * The UI will typically have responsibility for updating the {@code submissionStatus} before
+     * the {@link Submission} is submitted. Therefore, by default this service will not replace 
+     * the existing status of an unsubmitted record unless the starting value was null (i.e. it has not 
+     * been populated yet). To override this constraint, and replace the value anyway, use the method 
+     * {@code calculateAndUpdateSubmissionStatus(boolean overrideUIStatus)} and supply a parameter of {@code true}
+     * @return
+     */
+    public SubmissionStatus calculateAndUpdateSubmissionStatus() {
+        return calculateAndUpdateSubmissionStatus(false);
+    }
+    
+    
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@link Submission} provided. 
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for 
+     * {@code submitted} records, and {@link SubmissionEvent}s for unsubmitted records then updates 
+     * the status as appropriate. <br><br>
+     * The UI will typically have responsibility for updating the {@code submissionStatus} before
+     * the {@link Submission} is submitted. Therefore, by default this service will not replace 
+     * the existing status of an unsubmitted record unless the starting value was null (i.e. it has not 
+     * been populated yet). To override this constraint, set the {@code overrideUIStatus} parameter to 
+     * {@code true}
+     * @param overrideUIStatus - {@code true} will override the current pre-submission status on the 
+     * {@code Submission} record, regardless of whether it was set by the UI.
+     * {@code false} will not replace the current submission value, and favor the value set by the UI
+     * @return
+     */
+    public SubmissionStatus calculateAndUpdateSubmissionStatus(boolean overrideUIStatus) {
+        SubmissionStatus fromStatus = submission.getSubmissionStatus();
+        SubmissionStatus toStatus = calculateSubmissionStatus();
+
+        if (fromStatus==null || !fromStatus.equals(toStatus)) {
+            
+            //Applies special rule - this service should not overwrite what the UI has set the status to
+            //unless the original status was null or this service has been specifically configured to do so 
+            //by setting overrideUIStatus to true.
+            if (!overrideUIStatus && !submission.getSubmitted() && fromStatus!=null) {
+                LOG.info("Status of Submission {} did not change because pre-submission UI statuses are protected. "
+                        + "The current status will stay as `{}`", submission.getId(), fromStatus);      
+                return fromStatus;
+            }
+            
+            submission.setSubmissionStatus(toStatus);
+            LOG.info("Updating status of Submission {} from `{}` to `{}`", submission.getId(), fromStatus, toStatus);
+            client.updateResource(submission);
+            
+        } else {
+            LOG.debug("Status of Submission {} did not change. The current status is `{}`", submission.getId(), fromStatus);            
+        }
+        
+        return toStatus;
+    }
+    
+}

--- a/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
+++ b/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.util;
+
+import java.net.URI;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.model.SubmissionEvent.EventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.APPROVAL_REQUESTED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.CANCELLED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.CHANGES_REQUESTED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.COMPLETE;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.MANUSCRIPT_REQUIRED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.NEEDS_ATTENTION;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.SUBMITTED;
+
+/**
+ * A utility to calculate and validate the Submission Status. Separate calculations are provided depending
+ * on whether the Submission has been submitted or not since different data and rules apply 
+ *
+ * @author Karen Hanson
+ */
+public class SubmissionStatusCalculator  {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusCalculator.class);
+    
+    /**
+     * Calculates the appropriate post-Submission status based on data provided. 
+     * Post-Submission calculations uses the {@code Deposits} and {@code RepositoryCopies} associated 
+     * with a {@code Submission's} {@code Repositories} to determine the status of a Submission 
+     * after it has been submitted ({@code Submission.status=true}.
+     * @param repositories
+     * @param deposits
+     * @param repositoryCopies
+     * @return
+     */
+    public static SubmissionStatus calculatePostSubmissionStatus(List<URI> repositories,
+                                            List<Deposit> deposits,
+                                            List<RepositoryCopy> repositoryCopies) {
+        if (repositories==null || repositories.size()==0) {
+            throw new IllegalArgumentException("respositories cannot be null or empty when calculating a post-submission status.");
+        }
+        if (deposits==null) {deposits = new ArrayList<Deposit>();}
+        if (repositoryCopies==null) {repositoryCopies = new ArrayList<RepositoryCopy>();}
+        Map<URI, SubmissionStatus> statusMap = mapPostSubmissionRepositoryStatuses(repositories, deposits, repositoryCopies);
+        return calculateFromStatusMap(statusMap);        
+    }
+
+    
+    /**
+     * Calculates the appropriate pre-Submission status based on data provided. Pre-Submission 
+     * calculations use the {@code SubmissionEvents} associated with the {@link Submission} 
+     * to determine the status of a Submission before it has been submitted ({@code Submission.status=false}.
+     * @param submissionEvents
+     * @return
+     */
+    public static SubmissionStatus calculatePreSubmissionStatus(List<SubmissionEvent> submissionEvents) {
+    if (submissionEvents==null) {submissionEvents = new ArrayList<SubmissionEvent>();}
+        if (submissionEvents.size()>0) {
+            // should only be used to set a status if the status is starting as null since UI is best for setting status, 
+            // but will warn if the most recent event does not reflect current status
+            EventType mostRecentEventType = Collections
+                                                .max(submissionEvents, Comparator.comparing(SubmissionEvent::getPerformedDate))
+                                                .getEventType();
+
+            return mapEventTypeToSubmissionStatus(mostRecentEventType);
+            
+            
+        } else {
+            // has not yet been acted on, must be awaiting manuscript
+            return MANUSCRIPT_REQUIRED;
+        }
+    }
+    
+    
+
+    /**
+     * Checks validity of {@link SubmissionStatus} change, will throw exception or output a warning if there are any 
+     * validation issue with the change
+     * @param submitted
+     * @param fromStatus
+     * @param toStatus
+     */
+    public static void validateStatusChange(boolean submitted, SubmissionStatus fromStatus, SubmissionStatus toStatus) {
+        if (toStatus==null) {
+            throw new IllegalArgumentException("The new status cannot be null");
+        }
+        if (submitted) {
+            if (!toStatus.isSubmitted()) {
+                String msg = String.format("Failed to validate the change of status due to conflicting data. The status "
+                        + "`%s` cannot be assigned to a Submission that has not yet been submitted. There may be a data issue.", fromStatus);  
+                throw new RuntimeException(msg);
+            }  
+        } else {
+            if (toStatus.isSubmitted()) {
+                String msg = String.format("Failed to validate the change of status due to conflicting data. The status "
+                        + "`%s` cannot be assigned to a Submission that has already been submitted. There may be a data issue.", fromStatus);  
+                throw new RuntimeException(msg);
+            }
+            if (fromStatus!=null && fromStatus.isSubmitted()) {
+                String msg = String.format("Failed to validate the change of status due to conflicting data. The current "
+                        + "status of the Submission is `%s`. This indicates that the Submission was already submitted and "
+                        + "therefore should not be assigned a pre-submission status. There may be a data issue.", fromStatus);  
+                throw new RuntimeException(msg);
+            }
+    
+            if (fromStatus!=null && !toStatus.equals(fromStatus)) {
+                LOG.warn("The current status of the Submission conflicts with the status calculated based on the most recent SubmissionEvent. "
+                        + "The status on the Submission record is `{}`, while the calculated status is `{}`. The UI is responsible for setting "
+                        + "pre-Submission statuses, but this mismatch may indicate a data issue.", fromStatus, toStatus);                 
+            }  
+        }
+        
+    }
+    
+    
+    /**
+     * Use the Repository.id to SubmissionStatus Map to calculate the combined SubmissionStatus.
+     * @param submissionRepositoryStatusMap
+     * @return
+     */
+    private static SubmissionStatus calculateFromStatusMap(Map<URI, SubmissionStatus> submissionRepositoryStatusMap) {
+        //we only need to know if a status is present or not to determine combined status
+        Set<SubmissionStatus> statuses = new HashSet<SubmissionStatus>(submissionRepositoryStatusMap.values());        
+        
+        if (statuses.contains(NEEDS_ATTENTION)) {
+            return NEEDS_ATTENTION;
+        } else if (statuses.size()==1 && statuses.contains(COMPLETE)) {
+            return COMPLETE;
+        } else {
+            return SUBMITTED;
+        }
+    }
+    
+            
+    /**
+     * Calculates the individual post-submission status for each {@link Repository} by checking the status 
+     * of the matching {@link Deposit} and {@link RepositoryCopy} if either or both exist.
+     * @param repositories
+     * @param deposits
+     * @param repoCopies
+     * @return
+     */
+    private static Map<URI, SubmissionStatus> mapPostSubmissionRepositoryStatuses(List<URI> repositories, 
+                                                                                 List<Deposit> deposits, 
+                                                                                 List<RepositoryCopy> repoCopies) {
+
+        Map<URI, SubmissionStatus> statusMap = new HashMap<URI, SubmissionStatus>();
+        
+        for (URI repositoryUri : repositories) {
+            statusMap.put(repositoryUri, null);            
+        }
+        for (Deposit d : deposits) {
+            if (d.getDepositStatus().equals(DepositStatus.REJECTED)) {
+                statusMap.put(d.getRepository(), NEEDS_ATTENTION);                
+            } else {
+                statusMap.put(d.getRepository(), SUBMITTED);
+            }
+        }
+        for (RepositoryCopy rc : repoCopies) {
+            URI repoId = rc.getRepository();
+            CopyStatus copyStatus = rc.getCopyStatus();
+            if (copyStatus.equals(CopyStatus.COMPLETE)) {
+                statusMap.put(repoId, COMPLETE);
+            } else if (copyStatus.equals(CopyStatus.REJECTED) || copyStatus.equals(CopyStatus.STALLED)) {
+                statusMap.put(repoId, NEEDS_ATTENTION);
+            } else {
+                // There is a RepositoryCopy and nothing is wrong. Note in this state, it will overwrite a status of 
+                // REJECTED on the Deposit. This assumes that if all is OK with the RepositoryCopy things have been 
+                // resolved.
+                statusMap.put(repoId, SubmissionStatus.SUBMITTED);
+            }
+        }
+        
+        return statusMap;
+    }
+    
+    /**
+     * Maps the {@link EventType} to the corresponding {@code SubmissionStatus}
+     * @param eventType
+     * @return
+     */
+    private static SubmissionStatus mapEventTypeToSubmissionStatus(EventType eventType) {
+        switch (eventType) {
+            case APPROVAL_REQUESTED: return APPROVAL_REQUESTED;
+            case APPROVAL_REQUESTED_NEWUSER: return APPROVAL_REQUESTED;  
+            case SUBMITTED : return SUBMITTED;
+            case CANCELLED: return CANCELLED;
+            case CHANGES_REQUESTED: return CHANGES_REQUESTED;
+            default: return null;
+        }
+    }
+
+}

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusServiceTest.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusServiceTest.java
@@ -1,0 +1,119 @@
+package org.dataconservancy.pass.client;
+
+import java.net.URI;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.Submission;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.model.SubmissionEvent.EventType;
+import org.joda.time.DateTime;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for simple App.
+ */
+public class SubmissionStatusServiceTest extends SubmissionStatusTestBase {
+
+    @Mock
+    private PassClient client;
+
+    private SubmissionStatusService service;
+
+    @Before 
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    
+    /**
+     * Basic test to ensure that appropriate calls are made to client when calculating status
+     * of submitted Submission
+     * @throws Exception
+     */
+    @Test
+    public void testCalcSubmissionStatusPostSubmission() throws Exception {
+
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id);
+        Set<URI> depositUris = new HashSet<URI>(Arrays.asList(deposit1Id, deposit2Id));
+        Set<URI> repoCopyUris = new HashSet<URI>(Arrays.asList(repoCopy1Id, repoCopy2Id));
+        Set<URI> submissionEvents = new HashSet<URI>();
+        
+        Submission submission = new Submission();
+        submission.setId(new URI("submission:1"));
+        submission.setRepositories(repositories);
+        submission.setPublication(publicationId);
+        submission.setSubmitted(true);
+        
+        service = new SubmissionStatusService(submission, client);
+        
+        when(client.findAllByAttribute(eq(Deposit.class), eq("submission"), Mockito.any())).thenReturn(depositUris);
+        when(client.readResource(Mockito.any(), eq(Deposit.class))).thenReturn(deposit(DepositStatus.ACCEPTED, repo1Id)).thenReturn(deposit(DepositStatus.ACCEPTED, repo2Id));
+        
+        when(client.findAllByAttribute(eq(RepositoryCopy.class), eq("submission"), Mockito.any())).thenReturn(repoCopyUris);
+        when(client.readResource(Mockito.any(), eq(RepositoryCopy.class))).thenReturn(repoCopy(CopyStatus.ACCEPTED,repo1Id)).thenReturn(repoCopy(CopyStatus.ACCEPTED,repo2Id));
+        
+        when(client.findAllByAttribute(eq(SubmissionEvent.class), eq("submission"), Mockito.any())).thenReturn(submissionEvents);
+
+        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        assertEquals(SubmissionStatus.SUBMITTED, newStatus);
+
+        verify(client, Mockito.times(1)).findAllByAttribute(eq(Deposit.class),  eq("submission"), Mockito.any());
+        verify(client, Mockito.times(1)).findAllByAttribute(eq(RepositoryCopy.class), eq("publication"), Mockito.any());
+        verify(client, Mockito.times(0)).findAllByAttribute(eq(SubmissionEvent.class),  eq("submission"), Mockito.any());
+        
+    }
+    
+
+    /**
+     * Basic test to ensure that appropriate calls are made to client when calculating status of
+     * Submission not yet submitted.
+     * @throws Exception
+     */
+    @Test
+    public void testCalcSubmissionStatusPreSubmission() throws Exception {
+
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id);
+        Set<URI> submissionEventUris = new HashSet<URI>(Arrays.asList(subEvent1Id, subEvent2Id));
+        
+        Submission submission = new Submission();
+        submission.setId(new URI("submission:1"));
+        submission.setRepositories(repositories);
+        submission.setPublication(publicationId);
+        submission.setSubmitted(false);
+        
+        service = new SubmissionStatusService(submission, client);
+        
+        when(client.findAllByAttribute(eq(SubmissionEvent.class), eq("submission"), Mockito.any())).thenReturn(submissionEventUris);
+        when(client.readResource(Mockito.any(), eq(SubmissionEvent.class)))
+            .thenReturn(submissionEvent(new DateTime(2018, 2, 1, 12, 1, 0, 0), EventType.APPROVAL_REQUESTED))
+            .thenReturn(submissionEvent(new DateTime(2018, 2, 1, 12, 2, 0, 0), EventType.CHANGES_REQUESTED));
+
+        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED, newStatus);
+
+        verify(client, Mockito.times(0)).findAllByAttribute(eq(Deposit.class),  eq("submission"), Mockito.any());
+        verify(client, Mockito.times(0)).findAllByAttribute(eq(RepositoryCopy.class), eq("publication"), Mockito.any());
+        verify(client, Mockito.times(1)).findAllByAttribute(eq(SubmissionEvent.class),  eq("submission"), Mockito.any());
+        
+    }
+        
+}

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusTestBase.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusTestBase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client;
+
+import java.net.URI;
+
+import org.junit.Before;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.model.SubmissionEvent.EventType;
+import org.joda.time.DateTime;
+
+/**
+ * Some basic methods to support Submission Status testing.
+ * @author Karen Hanson
+ */
+public abstract class SubmissionStatusTestBase {
+
+    //some test URIs 
+    protected URI repo1Id;
+    protected URI repo2Id;
+    protected URI repo3Id;
+    protected URI publicationId;
+    protected URI deposit1Id;
+    protected URI deposit2Id;
+    protected URI repoCopy1Id;
+    protected URI repoCopy2Id;
+    protected URI subEvent1Id;
+    protected URI subEvent2Id;
+    
+    
+    @Before
+    public void initiate() throws Exception {
+        repo1Id = new URI("repository:1");
+        repo2Id = new URI("repository:2");
+        repo3Id = new URI("repository:3");
+        publicationId = new URI("publication:1");
+        deposit1Id = new URI("deposit:1");
+        deposit2Id = new URI("deposit:2");
+        repoCopy1Id = new URI("repositoryCopy:1");
+        repoCopy2Id = new URI("repositoryCopy:2");
+        subEvent1Id = new URI("submissionEvent:1");
+        subEvent2Id = new URI("submissionEvent:2");
+    }
+    
+    protected Deposit deposit(DepositStatus status, URI repoUri) {
+        Deposit d = new Deposit();
+        d.setDepositStatus(status);
+        d.setRepository(repoUri);
+        return d;
+    }
+
+
+    protected RepositoryCopy repoCopy(CopyStatus status, URI repoUri) {
+        RepositoryCopy r = new RepositoryCopy();
+        r.setCopyStatus(status);
+        r.setRepository(repoUri);
+        return r;
+    }
+    
+
+    protected SubmissionEvent submissionEvent(DateTime dt, EventType eventType) {
+        SubmissionEvent event = new SubmissionEvent();
+        event.setPerformedDate(dt);
+        event.setEventType(eventType);
+        return event;
+    }
+    
+}

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.util;
+
+import java.net.URI;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.dataconservancy.pass.client.SubmissionStatusTestBase;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Deposit.DepositStatus;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.SubmissionEvent;
+import org.dataconservancy.pass.model.SubmissionEvent.EventType;
+import org.joda.time.DateTime;
+
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.APPROVAL_REQUESTED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.CANCELLED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.CHANGES_REQUESTED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.COMPLETE;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.MANUSCRIPT_REQUIRED;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.NEEDS_ATTENTION;
+import static org.dataconservancy.pass.model.Submission.SubmissionStatus.SUBMITTED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the SubmissionStatusCalculator utility functions
+ * @author Karen Hanson
+ */
+public class SubmissionStatusCalculatorTest extends SubmissionStatusTestBase  {
+
+    /**
+     * 3 repositories listed, deposits only, no repositoryCopies. As long as none are rejected, it 
+     * should always be SUBMITTED
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositOnlySubmitted() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+                        
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.FAILED, repo2Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));        
+        
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.FAILED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null)); 
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));   
+        
+    }
+
+
+    /**
+     * 3 repositories listed, no deposits, repositoryCopies only. As long as none are rejected, it 
+     * should always be SUBMITTED
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOnlySubmitted() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+    
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));        
+
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));        
+    
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id), 
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));  
+          
+    }
+
+    
+    /**
+     * 3 repositories with various states for deposits and repositoryCopies all of which should come out as 
+     * having the status of SUBMITTED
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositAndRepoCopySubmitted() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+                        
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.FAILED, repo2Id));
+        
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.FAILED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));       
+    
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id), 
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));  
+                
+    }
+
+
+    /**
+     * Tests various situations with Deposits only that should trigger {@code SubmissionStatus.NEEDS_ATTENTION}
+     * as the {@code Submission.submissionStatus} value
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositOnlyNeedsAttention() throws Exception {
+        //1 repo 1 rejected deposit
+        List<URI> repositories = Arrays.asList(repo1Id);                        
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));   
+        
+        // 3 repo, 2 deposits, 1 rejected
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));        
+        
+        // 3 repo, 3 deposits, 1 rejected
+        deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));        
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));   
+        
+    }
+
+
+    /**
+     * Tests various situations with RepositoryCopies only that should trigger {@code SubmissionStatus.NEEDS_ATTENTION}
+     * as the {@code Submission.submissionStatus} value
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOnlyNeedsAttention() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.REJECTED, repo1Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));  
+        
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.STALLED, repo1Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));        
+
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.STALLED, repo2Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));        
+    
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.REJECTED, repo2Id), 
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));                  
+    }
+
+    
+    /**
+     * Various numbers of repositories with various states for deposits and repositoryCopies all of which 
+     * should come out as having status of {@code SubmissionStatus.NEEDS_ATTENTION}
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositAndRepoCopyNeedsAttention() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id, repo2Id);
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.REJECTED, repo2Id));
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.STALLED, repo2Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.IN_PROGRESS, repo1Id),
+                                         repoCopy(CopyStatus.REJECTED, repo2Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));       
+    
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.FAILED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo2Id), 
+                                         repoCopy(CopyStatus.STALLED, repo3Id));
+        assertEquals(NEEDS_ATTENTION, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));  
+                
+    }
+
+    
+    /**
+     * This confirms that if there are completed repository copies for each repository listed, the status is complete, 
+     * regardless of whether there is a deposit for each one or not.
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusComplete() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));        
+        assertEquals(COMPLETE, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+        
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id));
+        assertEquals(COMPLETE, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+        
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo3Id));
+        assertEquals(COMPLETE, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+        
+        assertEquals(COMPLETE, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+                
+    }
+
+    
+    /**
+     * This confirms that if you try to provide a null fo the repositories list it will throw an exception
+     * @throws Exception
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testPostSubmissionStatusNulls() throws Exception { 
+        SubmissionStatusCalculator.calculatePostSubmissionStatus(null, null, null);                
+    }
+
+    
+    /**
+     * This confirms that even if a Deposit is rejected, a RepositoryCopy's status will override the Deposit status
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOverrideDeposit() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id);
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id));
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+        assertEquals(COMPLETE, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.IN_PROGRESS, repo1Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+        
+        repositories = Arrays.asList(repo1Id, repo2Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo2Id));
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, repositoryCopies));
+                
+    }
+    
+
+    /**
+     * Confirms that MANUSCRIPT_REQUIRED is appropriately assigned as a pre-submission status.
+     */
+    @Test
+    public void testPreSubmissionStatusManuscriptExpected() {
+        assertEquals(MANUSCRIPT_REQUIRED, SubmissionStatusCalculator.calculatePreSubmissionStatus(null));
+        assertEquals(MANUSCRIPT_REQUIRED, SubmissionStatusCalculator.calculatePreSubmissionStatus(new ArrayList<SubmissionEvent>()));        
+    }
+    
+    /**
+     * Tests various scenarios where outcome should be APPROVAL_REQUESTED
+     */
+    @Test 
+    public void testPreSubmissionStatusApprovalRequested() {
+        List<SubmissionEvent> submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED));
+        assertEquals(APPROVAL_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents)); 
+
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED_NEWUSER));
+        assertEquals(APPROVAL_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents)); 
+        
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED_NEWUSER),
+                              submissionEvent(new DateTime(2018, 2, 2, 12, 0, 0, 0), EventType.CHANGES_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 3, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED));
+        assertEquals(APPROVAL_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents));         
+    }
+    
+
+    /**
+     * Tests various scenarios in which the pre-submission status should be "CHANGES_REQUESTED"
+     */
+    @Test 
+    public void testPreSubmissionStatusChangesRequested() {
+        List<SubmissionEvent> submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.CHANGES_REQUESTED));
+        assertEquals(CHANGES_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents)); 
+        
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 2, 12, 0, 0, 0), EventType.CHANGES_REQUESTED));
+        assertEquals(CHANGES_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents));    
+        
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 2, 0, 0), EventType.CHANGES_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 2, 3, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 2, 3, 1), EventType.CHANGES_REQUESTED));
+        assertEquals(CHANGES_REQUESTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents));          
+    }
+    
+
+    /**
+     * Tests various scenarios in which the pre-submission status should be "CANCELLED"
+     */
+    @Test 
+    public void testPreSubmissionStatusCancelled() {
+        List<SubmissionEvent> submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.CANCELLED));
+        assertEquals(CANCELLED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents)); 
+        
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 0, 0, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 2, 12, 0, 0, 0), EventType.CANCELLED));
+        assertEquals(CANCELLED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents));    
+        
+        submissionEvents = 
+                Arrays.asList(submissionEvent(new DateTime(2018, 2, 1, 12, 1, 0, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 2, 0, 0), EventType.CHANGES_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 3, 3, 0), EventType.APPROVAL_REQUESTED),
+                              submissionEvent(new DateTime(2018, 2, 1, 12, 4, 3, 1), EventType.CANCELLED));
+        assertEquals(CANCELLED, SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents));          
+    }
+    
+    /**
+     * Makes sure typical status changes log as valid. Some of these will generate warnings
+     * since this service is not supposed to change the pre-Submission statuses - it will warn
+     * when one is being changed.
+     */
+    @Test
+    public void testValidateStatusChangeOK() {
+        //if any of there throw exception the test fails:
+        SubmissionStatusCalculator.validateStatusChange(false, APPROVAL_REQUESTED, CHANGES_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, CHANGES_REQUESTED, APPROVAL_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, CHANGES_REQUESTED, CANCELLED);
+        SubmissionStatusCalculator.validateStatusChange(true, APPROVAL_REQUESTED, SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, MANUSCRIPT_REQUIRED, SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, SUBMITTED, COMPLETE);
+        SubmissionStatusCalculator.validateStatusChange(true, SUBMITTED, NEEDS_ATTENTION);
+        SubmissionStatusCalculator.validateStatusChange(true, NEEDS_ATTENTION, SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, NEEDS_ATTENTION, COMPLETE);        
+    }
+    
+    /**
+     * Makes sure typical invalid status changes are caught
+     */
+    @Test
+    public void testValidateStatusChangeException() {
+
+        //if any of there throw exception the test fails:
+        try {
+            //should fail based on assigning submitted status to unsubmitted 
+            SubmissionStatusCalculator.validateStatusChange(true, APPROVAL_REQUESTED, CHANGES_REQUESTED);
+            fail("Expected exception to be thrown");
+        } catch (Exception ex) {}
+
+        try {
+            //should fail based on change from submitted to unsubmitted status
+            SubmissionStatusCalculator.validateStatusChange(false, SUBMITTED, CANCELLED);
+            fail("Expected exception to be thrown");
+        } catch (Exception ex) {}    
+
+        try {
+            //should fail based on Submission have submitted=false but trying to assign post-submission status
+            SubmissionStatusCalculator.validateStatusChange(false, APPROVAL_REQUESTED, SUBMITTED);
+            fail("Expected exception to be thrown");
+        } catch (Exception ex) {}    
+
+        try {
+            //should be OK, but log should show a warning
+            SubmissionStatusCalculator.validateStatusChange(false, APPROVAL_REQUESTED, CHANGES_REQUESTED);
+        } catch (Exception ex) {
+            fail("Exception should not have been thrown, just a warning for this.");
+        }    
+    }
+    
+    
+    
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>pass-client-integration</module>
     <module>pass-test-data</module>
     <module>pass-client-shaded-v2_3</module>
+    <module>pass-status-service</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Adds a module for managing statuses, specifically:
* Adds a utility for calculating and validating `Submission.submissionStatus` based on relevant information from the `Submission`
* Adds a service to support calculating the status based on a Submission object or ID, and then updating the `Submission.submissionStatus` using the calculated value.
* Adds relevant tests and integration tests for the new module.

Question for reviewer: do you think this should be visible through the `pass-client-api` somehow? Wasn't sure it belonged in `PassClient`