### PR TITLE
Update versions of plugins and deps in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,34 +123,34 @@
     <scp.port>22</scp.port>
 
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-    <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
-    <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
-    <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
+    <docker-maven-plugin.version>0.27.2</docker-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-javadoc-pugin.version>3.0.1</maven-javadoc-pugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
-    <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
+    <maven.wagon.ssh.version>3.2.0</maven.wagon.ssh.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <commons-io.version>2.6</commons-io.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
-    <joda-time.version>2.9.9</joda-time.version>
-    <org-json.version>20180130</org-json.version>
+    <joda-time.version>2.10</joda-time.version>
+    <org-json.version>20180813</org-json.version>
     <junit.version>4.12</junit.version>
-    <jackson.version>2.9.4</jackson.version>
+    <jackson.version>2.9.7</jackson.version>
     <fcrepo-java-client.version>0.3.0</fcrepo-java-client.version>
     <logback.version>1.2.3</logback.version>
-    <mockito.version>2.22.0</mockito.version>
+    <mockito.version>2.23.0</mockito.version>
     <openpojo.version>0.8.10</openpojo.version>
-    <elasticsearch-client.version>6.2.3</elasticsearch-client.version>
+    <elasticsearch-client.version>6.2.4</elasticsearch-client.version>
     <slf4j.version>1.7.25</slf4j.version>
     <unitils.version>3.4.6</unitils.version>
-    <okhttp.version>3.10.0</okhttp.version>
-    <log4j2.version>2.9.1</log4j2.version>
+    <okhttp.version>3.11.0</okhttp.version>
+    <log4j2.version>2.11.1</log4j2.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Self explanatory. As a side benefit, this builds OK on Java 11 now.