### PR TITLE
Add maven and travis badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+
 # Java Fedora Client 
+[![Build Status](https://travis-ci.org/OA-PASS/java-fedora-client.png?branch=master)](https://travis-ci.org/OA-PASS/java-fedora-client)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.dataconservancy.pass/pass-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.dataconservancy.pass/)
+
 Java client for managing interactions with the PASS data in Fedora. Includes the data model represented as POJOs, annotated with Jackson for easy conversion to JSON.
 
 ## PASS POJOs


### PR DESCRIPTION
See it rendered here:
https://github.com/birkland/java-fedora-client/blob/1fe016f1ec5ae5d6be4fd4f5d368328f587058fe/README.md

The badge will pick up the latest release in maven central, so this serves as evidence that `0.3.5` (from the maintenance branch supporting model 2.3) made it in!

Resolves #60 