### PR TITLE
Use release version for shaded artifact

### DIFF
--- a/pass-client-shaded-v2_3/pom.xml
+++ b/pass-client-shaded-v2_3/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.dataconservancy.pass</groupId>
       <artifactId>pass-data-client</artifactId>
-      <version>0.3.4-SNAPSHOT</version>
+      <version>0.3.5</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Removal of the `SNAPSHOT` is a prerequisite to performing a release.