### PR TITLE
Remove Submission dependency from constructors of SubmissionStatusService

### DIFF
--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/SubmissionStatusServiceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/SubmissionStatusServiceIT.java
@@ -90,8 +90,8 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         URI subEvent2Id = client.createResource(subEvent2);
         this.createdUris.put(subEvent2Id, SubmissionEvent.class);
 
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
-        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        SubmissionStatusService service = new SubmissionStatusService();
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(submissionId);
         //check correct value returned
         assertEquals(SubmissionStatus.CANCELLED, newStatus);
         
@@ -135,8 +135,8 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         final URI subEvent2Id = client.createResource(subEvent2);
         this.createdUris.put(subEvent2Id, SubmissionEvent.class);
 
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
-        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        SubmissionStatusService service = new SubmissionStatusService();
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(submissionId);
         //check correct value returned
         assertEquals(SubmissionStatus.APPROVAL_REQUESTED, newStatus);
         
@@ -182,9 +182,9 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         URI subEvent2Id = client.createResource(subEvent2);
         this.createdUris.put(subEvent2Id, SubmissionEvent.class);
         
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatusService service = new SubmissionStatusService();
         //this time we set override to true
-        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(true);
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(submissionId, true);
         //check correct value returned
         assertEquals(SubmissionStatus.CHANGES_REQUESTED, newStatus);
         
@@ -229,9 +229,9 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         URI deposit2Id = client.createResource(deposit1);
         this.createdUris.put(deposit2Id, Deposit.class);
         
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatusService service = new SubmissionStatusService();
         //this time we set override to true
-        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(submissionId);
         //check correct value returned
         assertEquals(SubmissionStatus.SUBMITTED, newStatus);
         
@@ -293,9 +293,9 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         URI repoCopy2Id = client.createResource(repoCopy2);
         this.createdUris.put(repoCopy2Id, RepositoryCopy.class);
         
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
+        SubmissionStatusService service = new SubmissionStatusService();
         //this time we won't update Submission record, just return the value
-        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        SubmissionStatus newStatus = service.calculateSubmissionStatus(submissionId);
         assertEquals(SubmissionStatus.COMPLETE, newStatus);
         
         //also check database was not updated with the new value
@@ -350,8 +350,8 @@ public class SubmissionStatusServiceIT extends ClientITBase {
         URI repoCopy1Id = client.createResource(repoCopy1);
         this.createdUris.put(repoCopy1Id, RepositoryCopy.class);
 
-        SubmissionStatusService service = new SubmissionStatusService(submissionId);
-        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus();
+        SubmissionStatusService service = new SubmissionStatusService();
+        SubmissionStatus newStatus = service.calculateAndUpdateSubmissionStatus(submissionId);
         assertEquals(SubmissionStatus.NEEDS_ATTENTION, newStatus);
         
         //also check database was not updated with the new value

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusServiceTest.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/SubmissionStatusServiceTest.java
@@ -69,13 +69,13 @@ public class SubmissionStatusServiceTest extends SubmissionStatusTestBase {
         submission.setPublication(publicationId);
         submission.setSubmitted(true);
         
-        service = new SubmissionStatusService(submission, client);
+        service = new SubmissionStatusService(client);
         
         when(client.getIncoming(Mockito.any())).thenReturn(submissionIncoming).thenReturn(publicationsIncoming);;
         when(client.readResource(Mockito.any(), eq(Deposit.class))).thenReturn(deposit(DepositStatus.ACCEPTED, repo1Id)).thenReturn(deposit(DepositStatus.ACCEPTED, repo2Id));
         when(client.readResource(Mockito.any(), eq(RepositoryCopy.class))).thenReturn(repoCopy(CopyStatus.ACCEPTED,repo1Id)).thenReturn(repoCopy(CopyStatus.ACCEPTED,repo2Id));
         
-        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        SubmissionStatus newStatus = service.calculateSubmissionStatus(submission);
         assertEquals(SubmissionStatus.SUBMITTED, newStatus);
 
         verify(client, Mockito.times(2)).getIncoming(Mockito.any());
@@ -106,14 +106,14 @@ public class SubmissionStatusServiceTest extends SubmissionStatusTestBase {
         submission.setPublication(publicationId);
         submission.setSubmitted(false);
         
-        service = new SubmissionStatusService(submission, client);
+        service = new SubmissionStatusService(client);
         
         when(client.getIncoming(Mockito.any())).thenReturn(submissionIncoming);
         when(client.readResource(Mockito.any(), eq(SubmissionEvent.class)))
             .thenReturn(submissionEvent(new DateTime(2018, 2, 1, 12, 1, 0, 0), EventType.APPROVAL_REQUESTED))
             .thenReturn(submissionEvent(new DateTime(2018, 2, 1, 12, 2, 0, 0), EventType.CHANGES_REQUESTED));
 
-        SubmissionStatus newStatus = service.calculateSubmissionStatus();
+        SubmissionStatus newStatus = service.calculateSubmissionStatus(submission);
         assertEquals(SubmissionStatus.CHANGES_REQUESTED, newStatus);
 
         verify(client, Mockito.times(1)).getIncoming(Mockito.any());


### PR DESCRIPTION
Submission is no longer a dependency for `SubmissionStatusService`, but is instead passed in as a parameter to the various `calculate...` methods.

closes #73