### PR TITLE
Prevents status calc failure when status is NULL

### DIFF
--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
@@ -58,7 +58,7 @@ public class ElasticsearchPassClient {
     /**
      * Template for a search attribute e.g. AND fldname:"something"
      */
-    private static final String QS_ATTRIB_TEMPLATE  = "AND %s:\"%s\"";
+    private static final String QS_ATTRIB_TEMPLATE  = " AND %s:\"%s\"";
     
     /**
      * Template for a query string e.g. (@type:Submission AND fldname:"something")

--- a/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
+++ b/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
@@ -172,7 +172,7 @@ public class SubmissionStatusCalculator  {
             statusMap.put(repositoryUri, null);            
         }
         for (Deposit d : deposits) {
-            if (d.getDepositStatus()!=null && d.getDepositStatus().equals(DepositStatus.REJECTED)) {
+            if (DepositStatus.REJECTED.equals(d.getDepositStatus())) {
                 statusMap.put(d.getRepository(), NEEDS_ATTENTION);                
             } else {
                 statusMap.put(d.getRepository(), SUBMITTED);
@@ -181,9 +181,9 @@ public class SubmissionStatusCalculator  {
         for (RepositoryCopy rc : repoCopies) {
             URI repoId = rc.getRepository();
             CopyStatus copyStatus = rc.getCopyStatus();
-            if (copyStatus!=null && copyStatus.equals(CopyStatus.COMPLETE)) {
+            if (CopyStatus.COMPLETE.equals(copyStatus)) {
                 statusMap.put(repoId, COMPLETE);
-            } else if (copyStatus!=null && (copyStatus.equals(CopyStatus.REJECTED) || copyStatus.equals(CopyStatus.STALLED))) {
+            } else if (CopyStatus.REJECTED.equals(copyStatus) || CopyStatus.STALLED.equals(copyStatus)) {
                 statusMap.put(repoId, NEEDS_ATTENTION);
             } else {
                 // There is a RepositoryCopy and nothing is wrong. Note in this state, it will overwrite a status of 

--- a/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
+++ b/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.Deposit.DepositStatus;
-import org.dataconservancy.pass.model.Repository;
 import org.dataconservancy.pass.model.RepositoryCopy;
 import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
 import org.dataconservancy.pass.model.Submission;
@@ -173,7 +172,7 @@ public class SubmissionStatusCalculator  {
             statusMap.put(repositoryUri, null);            
         }
         for (Deposit d : deposits) {
-            if (d.getDepositStatus().equals(DepositStatus.REJECTED)) {
+            if (d.getDepositStatus()!=null && d.getDepositStatus().equals(DepositStatus.REJECTED)) {
                 statusMap.put(d.getRepository(), NEEDS_ATTENTION);                
             } else {
                 statusMap.put(d.getRepository(), SUBMITTED);
@@ -182,9 +181,9 @@ public class SubmissionStatusCalculator  {
         for (RepositoryCopy rc : repoCopies) {
             URI repoId = rc.getRepository();
             CopyStatus copyStatus = rc.getCopyStatus();
-            if (copyStatus.equals(CopyStatus.COMPLETE)) {
+            if (copyStatus!=null && copyStatus.equals(CopyStatus.COMPLETE)) {
                 statusMap.put(repoId, COMPLETE);
-            } else if (copyStatus.equals(CopyStatus.REJECTED) || copyStatus.equals(CopyStatus.STALLED)) {
+            } else if (copyStatus!=null && (copyStatus.equals(CopyStatus.REJECTED) || copyStatus.equals(CopyStatus.STALLED))) {
                 statusMap.put(repoId, NEEDS_ATTENTION);
             } else {
                 // There is a RepositoryCopy and nothing is wrong. Note in this state, it will overwrite a status of 

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
@@ -100,6 +100,32 @@ public class SubmissionStatusCalculatorTest extends SubmissionStatusTestBase  {
           
     }
 
+
+    /**
+     * 1 repositories listed, no deposits, repositoryCopy only. copyStatus is null
+     * @throws Exception
+     */
+    @Test
+    public void testSubmittedNoDepositCopyNoStatus() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(null, repo1Id));
+    
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+    }
+
+
+    /**
+     * 1 repositories listed, no deposits, repositoryCopy only. copyStatus is null
+     * @throws Exception
+     */
+    @Test
+    public void testSubmittedDepositNullStatusNoRepoCopy() throws Exception {
+        List<URI> repositories = Arrays.asList(repo1Id);
+        List<Deposit> deposits = Arrays.asList(deposit(null, repo1Id));
+    
+        assertEquals(SUBMITTED, SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+    }
+
     
     /**
      * 3 repositories with various states for deposits and repositoryCopies all of which should come out as 


### PR DESCRIPTION
Null status on RepositoryCopy or Deposit causes NPE. This patches the problem.
Also adds a space before the `AND` for multi-parameter Elasticsearch queries