### PR TITLE
Handles submissions with no repositories

### DIFF
--- a/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
+++ b/pass-status-service/src/main/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculator.java
@@ -70,9 +70,7 @@ public class SubmissionStatusCalculator  {
     public static SubmissionStatus calculatePostSubmissionStatus(List<URI> repositories,
                                             List<Deposit> deposits,
                                             List<RepositoryCopy> repositoryCopies) {
-        if (repositories==null || repositories.size()==0) {
-            throw new IllegalArgumentException("respositories cannot be null or empty when calculating a post-submission status.");
-        }
+        if (repositories==null) {repositories = new ArrayList<URI>();}
         if (deposits==null) {deposits = new ArrayList<Deposit>();}
         if (repositoryCopies==null) {repositoryCopies = new ArrayList<RepositoryCopy>();}
         Map<URI, SubmissionStatus> statusMap = mapPostSubmissionRepositoryStatuses(repositories, deposits, repositoryCopies);

--- a/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
+++ b/pass-status-service/src/test/java/org/dataconservancy/pass/client/util/SubmissionStatusCalculatorTest.java
@@ -28,6 +28,7 @@ import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.Deposit.DepositStatus;
 import org.dataconservancy.pass.model.RepositoryCopy;
 import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
+import org.dataconservancy.pass.model.Submission.SubmissionStatus;
 import org.dataconservancy.pass.model.SubmissionEvent;
 import org.dataconservancy.pass.model.SubmissionEvent.EventType;
 import org.joda.time.DateTime;
@@ -277,12 +278,15 @@ public class SubmissionStatusCalculatorTest extends SubmissionStatusTestBase  {
 
     
     /**
-     * This confirms that if you try to provide a null fo the repositories list it will throw an exception
+     * This confirms that if you try to provide a null for all values, it will assume submitted.
+     * This would only happen if the only repositories were web linked and therefore there is no 
+     * Deposit to process.
      * @throws Exception
      */
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testPostSubmissionStatusNulls() throws Exception { 
-        SubmissionStatusCalculator.calculatePostSubmissionStatus(null, null, null);                
+        SubmissionStatus status = SubmissionStatusCalculator.calculatePostSubmissionStatus(null, null, null);                
+        assertEquals(SubmissionStatus.SUBMITTED, status);
     }
 
     


### PR DESCRIPTION
Submissions with a single web-link repository will appear as having no repositories. This changes the behavior of the post-submission status calculation to mark the status as "submitted" instead of throwing an exception.

Closes #81 