### PR TITLE
Support matching of PASS resources by IP address/port pairs

### DIFF
--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
@@ -19,8 +19,12 @@ import java.net.URI;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.RecursiveAction;
 
 import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.dataconservancy.pass.model.File;
@@ -28,6 +32,7 @@ import org.dataconservancy.pass.model.Grant;
 import org.dataconservancy.pass.model.Submission;
 import org.dataconservancy.pass.model.User;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -175,5 +180,66 @@ public class FindAllByAttributeIT extends ClientITBase {
         }
         fail ("Test should have thrown exception");
     }
-    
+
+    /**
+     * Find a RepositoryCopy by matching on the IP address/port pair of the accessUrl.
+     * Can't do this right now because the accessUrl is incorrectly normalized as a Fedora URI.
+     */
+    @Test
+    @Ignore("Enable when accessUrl no longer has a normalizer")
+    public void testWildcardFindRepositoryCopyByMatchingAccessUrlWithIPandPort() {
+        RepositoryCopy repoCopy = random(RepositoryCopy.class, 1);
+        repoCopy = client.createAndReadResource(repoCopy, RepositoryCopy.class);
+        URI accessUrl = repoCopy.getId();
+        repoCopy.setAccessUrl(accessUrl);
+        client.updateResource(repoCopy);
+
+        String query = format("*%s:%s*", repoCopy.getId().getHost(), repoCopy.getId().getPort());
+
+        attempt(RETRIES, () -> {
+            URI u = client.findByAttribute(RepositoryCopy.class, "accessUrl", query);
+            RepositoryCopy rc = client.readResource(u, RepositoryCopy.class);
+            assertEquals(accessUrl, rc.getAccessUrl());
+        });
+    }
+
+    /**
+     * Find a Repository by matching on a portion of its description.
+     * Description is a keyword, no normalizer.
+     */
+    @Test
+    public void testWildcardFindRepositoryByDescriptionContainingSpaces() {
+        Repository repo = random(Repository.class, 1);
+        repo.setDescription("A description with spaces.");
+        URI repoUri = client.createResource(repo);
+        createdUris.put(repoUri, Repository.class);
+
+        String query = "*description with *";
+
+        attempt(RETRIES, () -> {
+            URI u = client.findByAttribute(Repository.class, "description", query);
+            Repository r = client.readResource(u, Repository.class);
+            assertEquals(repo.getDescription(), r.getDescription());
+        });
+    }
+
+    /**
+     * Find a Deposit by matching on the the IP address/port pair in the status ref.
+     * Status ref is a keyword, no normalizer.
+     */
+    @Test
+    public void testWildcardFindDepositByMatchingStatusRefWithIPandPort() {
+        Deposit deposit = random(Deposit.class, 1);
+        deposit.setDepositStatusRef("http://192.168.99.100:23412/some/path");
+        URI depositUri = client.createResource(deposit);
+        createdUris.put(depositUri, Deposit.class);
+
+        String query = format("*%s:%s*", "192.168.99.100", "23412");
+
+        attempt(RETRIES, () -> {
+            URI u = client.findByAttribute(Deposit.class, "depositStatusRef", query);
+            assertEquals(depositUri, client.readResource(u, Deposit.class).getId());
+        });
+    }
+
 }

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.http.HttpHost;
 
@@ -56,9 +57,9 @@ public class ElasticsearchPassClient {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchPassClient.class);
     
     /**
-     * Template for a search attribute e.g. AND fldname:"something"
+     * Template for a search attribute e.g. AND fldname:something
      */
-    private static final String QS_ATTRIB_TEMPLATE  = " AND %s:\"%s\"";
+    private static final String QS_ATTRIB_TEMPLATE = " AND %s:%s";
     
     /**
      * Template for a query string e.g. (@type:Submission AND fldname:"something")
@@ -70,7 +71,7 @@ public class ElasticsearchPassClient {
 
     private static final String NOT_EXISTS_TEMPLATE = "-" + EXISTS_TEMPLATE;
 
-    private static final String QS_ATTRIB_NOT_EXISTS_TEMPLATE = "AND " + NOT_EXISTS_TEMPLATE;
+    private static final String QS_ATTRIB_NOT_EXISTS_TEMPLATE = " AND " + NOT_EXISTS_TEMPLATE;
     
     private static final String ID_FIELDNAME = "@id";
 
@@ -113,13 +114,8 @@ public class ElasticsearchPassClient {
             indexType = PassEntityType.getTypeByName(modelClass.getSimpleName()).getName();
         }
 
-        String attribs = null;
-        if (value != null) {
-            attribs = String.format(QS_ATTRIB_TEMPLATE, attribute, value.toString());
-        } else {
-            attribs = String.format(QS_ATTRIB_NOT_EXISTS_TEMPLATE, attribute);
-        }
-        String querystring = String.format(QS_TEMPLATE, indexType, attribs);
+        String attribs = buildAttributeString(attribute, value);
+        String querystring = applyTemplate(QS_TEMPLATE, attribs, indexType);
              
         Set<URI> passEntityUris = getIndexerResults(querystring, 2, 0); //get 2 so we can check only one result matched
         if (passEntityUris.size()>1) {
@@ -173,13 +169,8 @@ public class ElasticsearchPassClient {
             indexType = PassEntityType.getTypeByName(modelClass.getSimpleName()).getName();
         }
 
-        String attribs = null;
-        if (value != null) {
-            attribs = String.format(QS_ATTRIB_TEMPLATE, attribute, value.toString());
-        } else {
-            attribs = String.format(NOT_EXISTS_TEMPLATE, attribute);
-        }
-        String querystring = String.format(QS_TEMPLATE, indexType, attribs);                
+        String attribs = buildAttributeString(attribute, value);
+        String querystring = applyTemplate(QS_TEMPLATE, attribs, indexType);
         Set<URI> passEntityUris = getIndexerResults(querystring, limit, offset);
         
         return passEntityUris;
@@ -221,22 +212,14 @@ public class ElasticsearchPassClient {
         if (PassEntityType.getTypeByName(modelClass.getSimpleName())!=null) {
             indexType = PassEntityType.getTypeByName(modelClass.getSimpleName()).getName();
         }
-        
-        StringBuilder attribs = new StringBuilder("");
-        for(Entry<String,Object> attr : valueAttributesMap.entrySet()) {
-            if (attr.getValue() != null) {
-                attribs.append(String.format(QS_ATTRIB_TEMPLATE, attr.getKey(), attr.getValue().toString()));
-            } else {
-                attribs.append(String.format(QS_ATTRIB_NOT_EXISTS_TEMPLATE, attr.getKey()));
-            }
-        }
-        String querystring = String.format(QS_TEMPLATE, indexType, attribs);
+
+        StringBuilder attribs = buildAttributeString(valueAttributesMap);
+        String querystring = applyTemplate(QS_TEMPLATE, attribs.toString(), indexType);
                 
         Set<URI> passEntityUris = getIndexerResults(querystring, limit, offset);
         return passEntityUris;
     }
-    
-    
+
     /**
      * Retrieve search results from elasticsearch
      * @param querystring
@@ -301,6 +284,125 @@ public class ElasticsearchPassClient {
         if (attribute==null || attribute.length()==0) {throw new IllegalArgumentException("attribute cannot be null or empty");}
         if (value instanceof Collection<?>) {throw new IllegalArgumentException("Value for attribute " + attribute + " cannot be a Collection");}
         if (value==null && !allowNullValues) {throw new IllegalArgumentException("Value cannot be null or empty");}
+    }
+
+    /**
+     * Applies the supplied arguments to the template.
+     *
+     * @param template
+     * @param attribs
+     * @param indexType
+     * @return
+     */
+    private static String applyTemplate(String template, String attribs, String indexType) {
+        return String.format(template, indexType, attribs);
+    }
+
+    /**
+     * Prepares the '{@code attribute:value}' portion of the Elastic Search query from a Map of attribute value pairs.
+     * <p>
+     * Each attribute value pair will be processed according to {@link #buildAttributeString(String, String)}.
+     * </p>
+     *
+     * @param valueAttributesMap a Map keyed by attribute names containing attribute values (which may be {@code null})
+     * @return a portion of the Elastic Search query; each {@code non-null} attribute value will be escaped
+     * @see #buildAttributeString(String, String)
+     */
+    static StringBuilder buildAttributeString(Map<String, Object> valueAttributesMap) {
+        StringBuilder sb = new StringBuilder();
+        for (Entry<String, Object> attr : valueAttributesMap.entrySet()) {
+            sb.append(buildAttributeString(attr.getKey(),
+                    (attr.getValue() == null) ? null : attr.getValue().toString()));
+        }
+
+        return sb;
+    }
+
+    /**
+     * Prepares the '{@code attribute:value}' portion of the Elastic Search query.
+     * <p>
+     * If the {@code attributeValue} is {@code null}, then the {@link #QS_ATTRIB_NOT_EXISTS_TEMPLATE} is applied.
+     * Otherwise, the {@code attributeValue} is processed to escape any special characters, then has the {@link
+     * #QS_ATTRIB_TEMPLATE} applied.
+     * </p>
+     *
+     * @param attributeName  the name of the Elastic Search query attribute
+     * @param attributeValue the (pre-escaped) Elastic Search attribute value, or {@code null}
+     * @return a portion of the Elastic Search query; escaped in the case of a {@code non-null} attribute value
+     */
+    static String buildAttributeString(String attributeName, Object attributeValue) {
+        return buildAttributeString(attributeName, (attributeValue == null) ? null : attributeValue.toString())
+                .toString();
+    }
+
+    /**
+     * Prepares the '{@code attribute:value}' portion of the Elastic Search query.
+     * <p>
+     * If the {@code attributeValue} is {@code null}, then the {@link #QS_ATTRIB_NOT_EXISTS_TEMPLATE} is applied.
+     * Otherwise, the {@code attributeValue} is processed to escape any special characters, then has the {@link
+     * #QS_ATTRIB_TEMPLATE} applied.
+     * </p>
+     *
+     * @param attributeName the name of the Elastic Search query attribute
+     * @param attributeValue the (pre-escaped) Elastic Search attribute value, or {@code null}
+     * @return a portion of the Elastic Search query; escaped in the case of a {@code non-null} attribute value
+     */
+    static StringBuilder buildAttributeString(String attributeName, String attributeValue) {
+        StringBuilder sb = new StringBuilder();
+        if (attributeValue != null) {
+            StringBuilder escapedValue = new StringBuilder(attributeValue);
+            escape(escapedValue);
+            sb.append(applyTemplate(QS_ATTRIB_TEMPLATE, escapedValue.toString(), attributeName));
+        } else {
+            sb.append(String.format(QS_ATTRIB_NOT_EXISTS_TEMPLATE, attributeName));
+        }
+
+        return sb;
+    }
+
+    /**
+     * Escapes special characters in the supplied string.  The supplied string should <em>not</em> be escaped already-
+     * there are no provisions in this method for detecting already-escaped strings.  If a string already contains
+     * escapes, it will be doubly-escaped.
+     * <p>
+     * This method simply returns the same StringBuilder it was supplied, as a convenience to the caller.
+     * </p>
+     *
+     * @param valueString the string which may contain special characters requiring escape
+     * @return the string with any special characters escaped
+     */
+    private static StringBuilder escape(StringBuilder valueString) {
+        // https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-query-string-query.html#_reserved_characters
+        // + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
+//        Stream.of("\\", "+", "-", "=", "&&", "||", ">", "<", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?", ":", "/")
+        Stream.of(":", "/")
+                .forEach((lookingFor) ->
+                    {
+                        String replacement = join("", "\\", lookingFor);
+//                        System.err.println(">> replacement '" + replacement + "'");
+                        replace(valueString.indexOf(lookingFor), lookingFor, replacement, valueString);
+                    });
+        return valueString;
+    }
+
+    /**
+     * Recursively searches the {@code builder} for the string {@code lookingFor} and replacing it with {@code
+     * replacement}.
+     *
+     * @param idx the index of {@code lookingFor} in {@code builder}, may be {@code -1}
+     * @param lookingFor the string being replaced in the {@code builder}
+     * @param replacement the string replacing {@code lookingFor}
+     * @param builder the string that may contain {@code lookingFor}
+     * @return -1
+     */
+    private static int replace(int idx, String lookingFor, String replacement, StringBuilder builder) {
+        if (idx > -1 && idx < builder.length()) {
+//            System.err.println(">> replacing character at index " + idx + " ('" + builder.charAt(idx) + "') with '" + replacement + "'");
+            builder.replace(idx, idx + 1, replacement);
+            return replace(builder.indexOf(lookingFor, idx + 2), lookingFor, replacement, builder);
+        } else {
+            return -1;
+        }
     }
     
 }

--- a/pass-data-client/src/test/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClientTest.java
+++ b/pass-data-client/src/test/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClientTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.client.elasticsearch;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.dataconservancy.pass.client.elasticsearch.ElasticsearchPassClient.buildAttributeString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class ElasticsearchPassClientTest {
+
+    private static final String DEFAULT_OP = " AND ";
+
+    private static final String DOESNT_EXIST_OP = "-_exists_";
+
+    @Test
+    public void colonEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "val:ue");
+            }
+        });
+
+        assertEquals("Expected ':' to be escaped in attribute string '" + result + "'",
+                1, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:val\\:ue", result.toString());
+    }
+
+    @Test
+    public void colonEscape() {
+        StringBuilder result = buildAttributeString("field", "val:ue");
+
+        assertEquals("Expected ':' to be escaped in attribute string '" + result + "'",
+                1, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:val\\:ue", result.toString());
+    }
+
+    @Test
+    public void adjacentColonEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "val::ue");
+            }
+        });
+
+        assertEquals("Expected every ':' to be escaped in attribute string '" + result + "'",
+                2, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:val\\:\\:ue", result.toString());
+    }
+
+    @Test
+    public void adjacentColonEscape() {
+        StringBuilder result = buildAttributeString("field", "val::ue");
+
+        assertEquals("Expected every ':' to be escaped in attribute string '" + result + "'",
+                2, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:val\\:\\:ue", result.toString());
+    }
+
+    @Test
+    public void beginningColonEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", ":value");
+            }
+        });
+
+        assertEquals("Expected ':' to be escaped in attribute string '" + result + "'",
+                1, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:\\:value", result.toString());
+    }
+
+    @Test
+    public void endingColonEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "value:");
+            }
+        });
+
+        assertTrue("Expected ':' to be escaped in attribute string '" + result + "'",
+                result.toString().endsWith("\\:"));
+        assertEquals(DEFAULT_OP + "field:value\\:", result.toString());
+    }
+
+    @Test
+    public void multipleColonEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "v:al:ue");
+            }
+        });
+
+        assertEquals("Expected every ':' to be escaped in attribute string '" + result + "'",
+                2, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:v\\:al\\:ue", result.toString());
+    }
+
+    @Test
+    public void noEscapeAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "value");
+            }
+        });
+
+        assertFalse("Expected non-escaped attribute string '" + result + "'",
+                result.toString().contains("\\:"));
+        assertEquals("Expected non-escaped attribute string '" + result + "'",
+                0, occurs("\\:", result.toString()));
+        assertEquals(DEFAULT_OP + "field:value", result.toString());
+    }
+
+    @Test
+    public void alreadyEscapedAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("field", "val\\:ue");
+            }
+        });
+
+        assertTrue("Expected : to be doubly-escaped in attribute string '" + result + "'",
+                result.toString().contains("\\\\:"));
+        assertEquals(DEFAULT_OP + "field:val\\\\:ue", result.toString());
+    }
+
+    @Test
+    public void passEntityIdAsMap() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("@id", "http://fcrepo:8080/fcrepo/rest/submissions/ab/cd/ef/abcdef");
+            }
+        });
+
+        assertEquals("Expected every ':' to be escaped in attribute value '" + result + "'",
+                2, occurs("\\:", result.toString()));
+        assertEquals("Expected every '/' to be escaped in attribute value '" + result + "'",
+                9, occurs("\\/", result.toString()));
+        assertEquals(DEFAULT_OP + "@id:http\\:\\/\\/fcrepo\\:8080\\/fcrepo\\/rest\\/submissions\\/ab\\/cd\\/ef\\/abcdef", result.toString());
+    }
+
+    @Test
+    public void attributeMapContainingNull() {
+        StringBuilder result = buildAttributeString(new HashMap<String, Object>() {
+            {
+                put("foo", "bar");
+                put("biz", null);
+                put("baz", "foo");
+            }
+        });
+
+        assertEquals(DEFAULT_OP + DOESNT_EXIST_OP + ":biz" + DEFAULT_OP + "foo:bar" + DEFAULT_OP + "baz:foo",
+                result.toString());
+    }
+
+    @Test
+    public void buildAttributeStringFromMap() {
+        Map<String, Object> attrMap = new HashMap<String, Object>() {
+            {
+                put("foo", "bar");
+                put("baz", "biz");
+            }
+        };
+
+        StringBuilder result = buildAttributeString(attrMap);
+
+        assertEquals(2, occurs("AND", result.toString()));
+        assertEquals(1, occurs("foo:bar", result.toString()));
+        assertEquals(1, occurs("baz:biz", result.toString()));
+        assertEquals(DEFAULT_OP + "foo:bar" + DEFAULT_OP + "baz:biz", result.toString());
+    }
+
+    @Test
+    public void buildAndEscapeAttributeStringFromMap() {
+        Map<String, Object> attrMap = new HashMap<String, Object>() {
+            {
+                put("foo", "b:ar");
+                put("baz", "[biz]");
+            }
+        };
+
+        StringBuilder result = buildAttributeString(attrMap);
+
+        assertEquals(result.toString(), 2, occurs("AND", result.toString()));
+        assertEquals(result.toString(), 1, occurs("foo:b\\:ar", result.toString()));
+        assertEquals(result.toString(), 1, occurs("baz:[biz]", result.toString()));
+        assertEquals(DEFAULT_OP + "foo:b\\:ar" + DEFAULT_OP + "baz:[biz]", result.toString());
+    }
+
+    private static int occurs(String needle, String haystack) {
+        int idx = -1;
+        int occurs = 0;
+
+        do {
+            idx = haystack.indexOf(needle, idx + 1);
+            occurs++;
+        } while (idx > -1);
+
+        return occurs == -1 ? 0 : occurs - 1;
+    }
+}


### PR DESCRIPTION
The PASS client does not currently support wildcard matching of PASS resources using IP address/port pairs.

For fields configured with the `fedora_uri` normalizer, this is expected.  A query attempting to match part of an `@id` (normalized as a `fedora_uri`) with something like: `@id:*192.168.99.100:45634*` will fail with both the Elastic API and the PASS client because the `fedora_uri` normalizer strips off the leading portion of the URL.

However, a similar query against keyword fields _absent a normalizer_ will fail.  Using the PASS client, a query like `depositStatusRef:*192.168.99.100:45634*` will fail, but will - if properly escaped, succeed using the Elastic API.

For example, this will fail:

```java
    @Test
    public void testWildcardFindDepositByMatchingStatusRefWithIPandPort() {
        Deposit deposit = random(Deposit.class, 1);
        deposit.setDepositStatusRef("http://192.168.99.100:53534/some/path");
        URI depositUri = client.createResource(deposit);

        String query = format("*%s:%s*", "192.168.99.100", "53534");

        attempt(RETRIES, () -> {
            URI u = client.findByAttribute(Deposit.class, "depositStatusRef", query);
            assertEquals(depositUri, client.readResource(u, Deposit.class).getId());
        });
    }
```

But `http://192.168.99.100:53537/pass/_search?q=@type:Deposit+depositStatusRef:*192.168.99.100\:53534*&pretty&default_operator=AND` will succeed (the colon separating the IP and port is escaped).

This PR updates the `ElasticsearchPassClient` by:
1. Removing the double quotes that surrounded query expressions
2. Escapes `:` and `/` if it found in an attribute value
3. Adds more tests

I suspect that this is not a general solution to this issue.  For example, the [ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-query-string-query.html#_reserved_characters) indicates there are many reserved words (`:` and `/` are only two of many).  Which characters require escaping may depend on the type of query (e.g. `-` for a range query) and on the ES mappings for the field.  My investigation demonstrated that simply escaping every reserved word carte blanche was incorrect, so this PR limits the escaping to only `:`and `/`.

There are two commits in the PR: the ITs, and then the changes.  You can check out the commit with the ITs to see them fail (and do any diagnosis or troubleshooting on your own), and then apply the fix and see success.

Finally, there is one IT that is currently ignored, because the field needs to have its ES mapping updated (removal of the normalizer).  Once that happens, a subsequent PR can enable the test.