### PR TITLE
Use Sonatype for hosting snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,9 +433,8 @@
     </repository>
 
     <snapshotRepository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Snapshot Maven Repository</name>
-      <url>scp://maven.dataconservancy.org:${scp.port}/data/maven-dc/public/snapshots/</url>
+      <id>maven-central-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <uniqueVersion>false</uniqueVersion>
     </snapshotRepository>
 
@@ -451,18 +450,6 @@
       <releases>
         <enabled>false</enabled>
       </releases>
-    </repository>
-    <repository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Public Maven Repository (snapshots)</name>
-      <layout>default</layout>
-      <url>http://maven.dataconservancy.org/public/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,18 +72,6 @@
   <profiles>
 
     <profile>
-      <id>external</id>
-      <activation>
-        <property>
-          <name>external</name>
-        </property>
-      </activation>
-      <properties>
-        <scp.port>122</scp.port>
-      </properties>
-    </profile>
-
-    <profile>
       <id>release</id>
       <build>
         <pluginManagement>
@@ -118,7 +106,6 @@
   </profiles>
 
   <properties>
-    <scp.port>22</scp.port>
 
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.27.2</docker-maven-plugin.version>


### PR DESCRIPTION
Update build to deploy snapshot artifacts to Maven Central infrastructure rather than Data Conservancy infrastructure.