### PR TITLE
WIP: Update User.affiliation and Contributer.affiliation to Set<String>

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-api</artifactId>
   <name>pass-client-api</name>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-integration</artifactId>
 

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -179,6 +179,7 @@
           <systemProperties>
             <pass.fedora.baseurl>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest/</pass.fedora.baseurl>
             <pass.elasticsearch.url>http://${ES_HOST}:${ES_PORT}</pass.elasticsearch.url>
+            <pass.jsonld.context>https://raw.githubusercontent.com/emetsger/pass-data-model/affiliation-fix/src/main/resources/context-3.5.jsonld</pass.jsonld.context>
           </systemProperties>
           <trimStackTrace>false</trimStackTrace>
         </configuration>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -179,7 +179,6 @@
           <systemProperties>
             <pass.fedora.baseurl>http://${FCREPO_HOST}:${FCREPO_PORT}/fcrepo/rest/</pass.fedora.baseurl>
             <pass.elasticsearch.url>http://${ES_HOST}:${ES_PORT}</pass.elasticsearch.url>
-            <pass.jsonld.context>https://raw.githubusercontent.com/emetsger/pass-data-model/affiliation-fix/src/main/resources/context-3.5.jsonld</pass.jsonld.context>
           </systemProperties>
           <trimStackTrace>false</trimStackTrace>
         </configuration>

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/ClientITBase.java
@@ -23,9 +23,11 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -219,6 +221,8 @@ public abstract class ClientITBase {
                         m.invoke(entity, createList(m, sizeOfLists));
                     } else if (Boolean.class.isAssignableFrom(type)) {
                         m.invoke(entity, true);
+                    } else if (Set.class.isAssignableFrom(type)) {
+                        m.invoke(entity, createSet(m, sizeOfLists));
                     } else {
                         throw new UnsupportedOperationException(type.getName());
                     }
@@ -255,6 +259,15 @@ public abstract class ClientITBase {
         }
 
         return list;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Set<?> createSet(Method method, int size) throws Exception {
+        final Set set = new HashSet<>();
+        for (int i = 0; i < size; i++) {
+            set.add(UUID.randomUUID().toString());
+        }
+        return set;
     }
 
     /**

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateFindByRoundTripIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/CreateFindByRoundTripIT.java
@@ -80,6 +80,9 @@ public class CreateFindByRoundTripIT extends ClientITBase {
                     if (List.class.isAssignableFrom(type)) {
                         List listval = (List) m.invoke(forDeposit);
                         val = listval.get(0);
+                    } else if (Set.class.isAssignableFrom(type)) {
+                        Set setval = (Set) m.invoke(forDeposit);
+                        val = setval.iterator().next();
                     } else {
                         val = m.invoke(forDeposit);
                     } 

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributeIT.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.client.integration;
 
 import java.net.URI;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class FindAllByAttributeIT extends ClientITBase {
         user.setFirstName("Mary-Ann");
         user.setLastName("Schäfer");
         user.setDisplayName("Mary \"The Shark\" Schäfer");
-        user.setAffiliation("Lamar & Schäfer Laboratory, Nürnberg");
+        user.setAffiliation(Collections.singleton("Lamar & Schäfer Laboratory, Nürnberg"));
         URI userId1 = client.createResource(user);
         createdUris.put(userId1, User.class);  
         URI userId2 = client.createResource(user);
@@ -81,7 +82,7 @@ public class FindAllByAttributeIT extends ClientITBase {
         assertTrue(uris.contains(userId1));
         assertTrue(uris.contains(userId2));
         
-        uris = client.findAllByAttribute(User.class, "affiliation", user.getAffiliation());
+        uris = client.findAllByAttribute(User.class, "affiliation", user.getAffiliation().iterator().next());
         assertEquals(2, uris.size());
         assertTrue(uris.contains(userId1));
         assertTrue(uris.contains(userId2));

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindAllByAttributesIT.java
@@ -18,6 +18,7 @@ package org.dataconservancy.pass.client.integration;
 import java.net.URI;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class FindAllByAttributesIT extends ClientITBase {
         user.setFirstName("Mary-Ann");
         user.setLastName("Schäfer");
         user.setDisplayName("Mary \"The Shark\" Schäfer");
-        user.setAffiliation("Lamar & Schäfer Laboratory, Nürnberg");
+        user.setAffiliation(Collections.singleton("Lamar & Schäfer Laboratory, Nürnberg"));
         URI userId1 = client.createResource(user);
         createdUris.put(userId1, User.class);  
         URI userId2 = client.createResource(user);
@@ -83,8 +84,8 @@ public class FindAllByAttributesIT extends ClientITBase {
         map.put("firstName", user.getFirstName());
         map.put("lastName", user.getLastName());
         map.put("displayName", user.getDisplayName());
-        map.put("affiliation", user.getAffiliation());
-                    
+        map.put("affiliation", user.getAffiliation().iterator().next());
+
         Set<URI> uris = client.findAllByAttributes(User.class, map);
         assertEquals(2, uris.size());
         assertTrue(uris.contains(userId1));

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/FindByAttributeIT.java
@@ -18,6 +18,7 @@ package org.dataconservancy.pass.client.integration;
 import java.net.URI;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Rule;
@@ -80,7 +81,7 @@ public class FindByAttributeIT extends ClientITBase {
         user.setFirstName("Mary-Ann");
         user.setLastName("Schäfer");
         user.setDisplayName("Mary \"The Shark\" Schäfer");
-        user.setAffiliation("Lamar & Schäfer Laboratory, Nürnberg");
+        user.setAffiliation(Collections.singleton("Lamar & Schäfer Laboratory, Nürnberg"));
         URI userId = client.createResource(user);
         createdUris.put(userId, User.class);
         
@@ -98,7 +99,7 @@ public class FindByAttributeIT extends ClientITBase {
         URI uri3 = client.findByAttribute(User.class, "displayName", user.getDisplayName());
         assertEquals(userId, uri3);
 
-        URI uri4 = client.findByAttribute(User.class, "affiliation", user.getAffiliation());
+        URI uri4 = client.findByAttribute(User.class, "affiliation", user.getAffiliation().iterator().next());
         assertEquals(userId, uri4);
         
     }

--- a/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
+++ b/pass-client-integration/src/test/java/org/dataconservancy/pass/client/integration/UpdateResourceIT.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -142,7 +143,7 @@ public class UpdateResourceIT extends ClientITBase {
         //verify User record does not have original fields, they have been completely overwritten with the partial model
         User updatedUser = overwriteOnUpdateClient.readResource(userId, User.class);
         assertEquals(userId, updatedUser.getId());
-        assertEquals(null, updatedUser.getAffiliation());
+        assertEquals(Collections.emptySet(), updatedUser.getAffiliation());
         assertEquals(null, updatedUser.getFirstName());
         assertEquals(null, updatedUser.getLastName());
         assertEquals(incompleteUser.getDisplayName(), updatedUser.getDisplayName());

--- a/pass-client-shaded-v2_3/pom.xml
+++ b/pass-client-shaded-v2_3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-shaded-v2_3</artifactId>
   <packaging>jar</packaging>

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-client-util</artifactId>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-data-client</artifactId>
   <name>PASS Data Client</name>

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-json-adapter</artifactId>
   

--- a/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
+++ b/pass-json-adapter/src/main/java/org/dataconservancy/pass/client/adapter/PassJsonAdapterBasic.java
@@ -40,7 +40,7 @@ public class PassJsonAdapterBasic implements PassJsonAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(PassJsonAdapterBasic.class);
     
     private final static String CONTEXT_PROPKEY = "pass.jsonld.context";
-    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld";
+    private final static String DEFAULT_CONTEXT = "https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.5.jsonld";
     
     /**
      * {@inheritDoc}

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-model</artifactId>
   <name>PASS Core Data Model</name>

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/Contributor.java
@@ -19,8 +19,10 @@ import java.net.URI;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -62,12 +64,12 @@ public class Contributor extends PassEntity {
      * ORCID ID for person 
      */
     private String orcidId;
-    
-    /** 
-     * Affiliation string for person. Where Person is embedded in Submission or Grant, 
-     * this is the affiliation relevant to that item 
+
+    /**
+     * Affiliation string for person. Where Person is embedded in Submission or Grant,
+     * this is the affiliation relevant to that item
      */
-    private String affiliation; 
+    private Set<String> affiliation = new HashSet<>();
     
     /** 
      * One or more roles that this Contributor performed for the associated Publication
@@ -245,7 +247,7 @@ public class Contributor extends PassEntity {
     /**
      * @return the affiliation
      */
-    public String getAffiliation() {
+    public Set<String> getAffiliation() {
         return affiliation;
     }
 
@@ -253,7 +255,7 @@ public class Contributor extends PassEntity {
     /**
      * @param affiliation the affiliation to set
      */
-    public void setAffiliation(String affiliation) {
+    public void setAffiliation(Set<String> affiliation) {
         this.affiliation = affiliation;
     }
 

--- a/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
+++ b/pass-model/src/main/java/org/dataconservancy/pass/model/User.java
@@ -17,8 +17,10 @@ package org.dataconservancy.pass.model;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -59,12 +61,12 @@ public class User extends PassEntity {
      * Contact email for User
      */
     private String email;
-    
-    /** 
-     * Affiliation string for person. Where Person is embedded in Submission or Grant, 
-     * this is the affiliation relevant to that item 
+
+    /**
+     * Affiliation string for person. Where Person is embedded in Submission or Grant,
+     * this is the affiliation relevant to that item
      */
-    private String affiliation; 
+    private Set<String> affiliation = new HashSet<>();
     
     /** 
      * A list of ids associated with the user by various system that PASS interacts with. 
@@ -103,7 +105,7 @@ public class User extends PassEntity {
         this.lastName = user.lastName;
         this.displayName = user.displayName;
         this.email = user.email;
-        this.affiliation = user.affiliation;
+        this.affiliation = new HashSet<>(user.affiliation);
         this.locatorIds = new ArrayList<String>(user.locatorIds);
         this.orcidId = user.orcidId;
         this.roles = new ArrayList<Role>(user.roles);
@@ -251,7 +253,7 @@ public class User extends PassEntity {
     /**
      * @return the affiliation
      */
-    public String getAffiliation() {
+    public Set<String> getAffiliation() {
         return affiliation;
     }
 
@@ -259,7 +261,7 @@ public class User extends PassEntity {
     /**
      * @param affiliation the affiliation to set
      */
-    public void setAffiliation(String affiliation) {
+    public void setAffiliation(Set<String> affiliation) {
         this.affiliation = affiliation;
     }
 

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/ContributorModelTests.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/ContributorModelTests.java
@@ -82,7 +82,7 @@ public class ContributorModelTests {
         assertEquals(root.getString("displayName"),TestValues.USER_DISPLAY_NAME);
         assertEquals(root.getString("email"),TestValues.USER_EMAIL);            
         assertEquals(root.getString("orcidId"),TestValues.USER_ORCID_ID);                
-        assertEquals(root.getString("affiliation"),TestValues.USER_AFFILIATION);         
+        assertEquals(root.getJSONArray("affiliation").get(0),TestValues.USER_AFFILIATION.iterator().next());
     }
     
     /**

--- a/pass-model/src/test/java/org/dataconservancy/pass/model/UserModelTest.java
+++ b/pass-model/src/test/java/org/dataconservancy/pass/model/UserModelTest.java
@@ -87,7 +87,7 @@ public class UserModelTest {
         assertEquals(root.getString("lastName"),TestValues.USER_LAST_NAME);
         assertEquals(root.getString("displayName"),TestValues.USER_DISPLAY_NAME);
         assertEquals(root.getString("email"),TestValues.USER_EMAIL);        
-        assertEquals(root.getString("affiliation"),TestValues.USER_AFFILIATION);         
+        assertEquals(root.getJSONArray("affiliation").get(0),TestValues.USER_AFFILIATION.iterator().next());
         assertEquals(root.getJSONArray("locatorIds").get(0),TestValues.USER_LOCATORID1);
         assertEquals(root.getJSONArray("locatorIds").get(1),TestValues.USER_LOCATORID2);   
         assertEquals(root.getString("orcidId"),TestValues.USER_ORCID_ID);              

--- a/pass-status-service/pom.xml
+++ b/pass-status-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-status-service</artifactId>
   <name>PASS Status Utility</name>

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-client</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>pass-test-data</artifactId>
   <name>PASS Test Data</name>

--- a/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
+++ b/pass-test-data/src/main/java/org/dataconservancy/pass/model/TestValues.java
@@ -16,6 +16,9 @@
 
 package org.dataconservancy.pass.model;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Constants used in test data
  *
@@ -299,7 +302,9 @@ public class TestValues {
     public static final String USER_ORCID_ID = "https://orcid.org/0000-1111-2222-3333";
 
     /** A test value */
-    public static final String USER_AFFILIATION = "Johns Hopkins University";
+    public static final Set<String> USER_AFFILIATION = new HashSet<String>() {{
+        add("Johns Hopkins University");
+    }};
 
     /** A test value */
     public static final String USER_ROLE_1 = "admin";

--- a/pass-test-data/src/main/resources/contributor.json
+++ b/pass-test-data/src/main/resources/contributor.json
@@ -8,7 +8,7 @@
 	"email": "js@example.com",
 	"institutionalId": "jms001",
 	"orcidId": "https://orcid.org/0000-1111-2222-3333",
-	"affiliation": "Johns Hopkins University",
+	"affiliation": [ "Johns Hopkins University" ],
 	"roles": ["first-author","author"],
 	"publication": "https://example.org/fedora/publications/1",
 	"user": "https://example.org/fedora/users/1"

--- a/pass-test-data/src/main/resources/user.json
+++ b/pass-test-data/src/main/resources/user.json
@@ -7,7 +7,7 @@
 	"lastName": "Smith",
 	"displayName": "June Smith",
 	"email": "js@example.com",
-	"affiliation": "Johns Hopkins University",
+	"affiliation": [ "Johns Hopkins University" ],
 	"locatorIds": ["johnshopkins.edu:employeeid:12345","johnshopkins.edu:hopkinsid:DRA2D"],
 	"orcidId": "https://orcid.org/0000-1111-2222-3333",
 	"roles": ["admin","submitter"]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
-  <version>0.6.1-SNAPSHOT</version>
+  <version>0.7.0-SNAPSHOT</version>
   <name>PASS Client Tool</name>
   <description>Client for interacting with the PASS Fedora+LDP repository</description>
   <url>https://github.com/OA-PASS/java-fedora-client</url>


### PR DESCRIPTION
- Bumps version to 0.7.0-SNAPSHOT from 0.6.1-SNAPSHOT, since this represents an incompatible change.
- Migrates User.affiliation and Contributer.affiliation to `Set<String>` from `String`
- Sets the default JSON-LD context to version 3.5.

**N.B.** Travis won't pass until https://github.com/OA-PASS/pass-data-model/pull/62 is merged.