### PR TITLE
Fix Elasticsearch configuration to be able to specify indices in search

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ a system property `-Dpass.fedora.user=myUser` or as an environment variable `PAS
 * pass.fedora.baseurl (default=http://localhost:8080/fcrepo/rest)
 * pass.fedora.user (default=fedoraAdmin)
 * pass.fedora.password (default=moo)
-* pass.elasticsearch.url (defaults = http://localhost:9200/pass)
+* pass.elasticsearch.url (defaults = http://localhost:9200)
+* pass.elasticsearch.indices (default = pass)
 * pass.elasticsearch.limit (defaults = 200) you can also override the default by using the findBy functions that accept a limit and offset value
 
 ## Integration tests with Fedora and Elasticsearch

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchConfig.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchConfig.java
@@ -34,7 +34,10 @@ public class ElasticsearchConfig {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchConfig.class);
     
     private static final String INDEXER_URL_KEY = "pass.elasticsearch.url";
-    private static final String DEFAULT_INDEXER_URL = "http://localhost:9200/pass";
+    private static final String DEFAULT_INDEXER_URL = "http://localhost:9200";
+
+    private static final String INDEXES_KEY = "pass.elasticsearch.indices";
+    private static final String DEFAULT_INDICES = "pass";
     
     private static final String INDEXER_LIMIT_KEY = "pass.elasticsearch.limit";
     private static final Integer DEFAULT_INDEXER_LIMIT = 200;
@@ -61,7 +64,19 @@ public class ElasticsearchConfig {
         return urls;
     }
 
-    
+
+    /**
+     * Get indexes to search, defaults to DEFAULT_INDEXES if not set
+     * @return indices
+     */
+
+    public static String[] getIndices() {
+        String sIndices =  ConfigUtil.getSystemProperty(INDEXES_KEY, DEFAULT_INDICES);
+        String[] arrIndices = sIndices.split( ",");
+        LOG.debug("Using index array of {} ", arrIndices.toString() );
+        return arrIndices;
+    }
+
     /**
      * Get indexer limit setting, defaults to DEFAULT_INDEXER_LIMIT if environment variable not set
      * @return indexer limit.

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchConfig.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchConfig.java
@@ -36,7 +36,7 @@ public class ElasticsearchConfig {
     private static final String INDEXER_URL_KEY = "pass.elasticsearch.url";
     private static final String DEFAULT_INDEXER_URL = "http://localhost:9200";
 
-    private static final String INDEXES_KEY = "pass.elasticsearch.indices";
+    private static final String INDICES_KEY = "pass.elasticsearch.indices";
     private static final String DEFAULT_INDICES = "pass";
     
     private static final String INDEXER_LIMIT_KEY = "pass.elasticsearch.limit";
@@ -71,7 +71,7 @@ public class ElasticsearchConfig {
      */
 
     public static String[] getIndices() {
-        String sIndices =  ConfigUtil.getSystemProperty(INDEXES_KEY, DEFAULT_INDICES);
+        String sIndices =  ConfigUtil.getSystemProperty(INDICES_KEY, DEFAULT_INDICES);
         String[] arrIndices = sIndices.split( ",");
         LOG.debug("Using index array of {} ", arrIndices.toString() );
         return arrIndices;

--- a/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
+++ b/pass-data-client/src/main/java/org/dataconservancy/pass/client/elasticsearch/ElasticsearchPassClient.java
@@ -78,7 +78,12 @@ public class ElasticsearchPassClient {
      * URL(s) of indexer
      */
     private final HttpHost[] hosts;
-        
+
+    /**
+     * names of indexes
+     */
+    private final String[] indices;
+
     /** 
      * Default constructor for PASS client
      */
@@ -91,7 +96,7 @@ public class ElasticsearchPassClient {
             hosts[count] = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
             count = count+1;
         }
-        
+        indices = ElasticsearchConfig.getIndices();
     }
     
     /**
@@ -262,6 +267,7 @@ public class ElasticsearchPassClient {
             matchQueryBuilder.defaultOperator(Operator.AND);
             sourceBuilder.query(matchQueryBuilder);
             searchRequest.source(sourceBuilder);
+            searchRequest.indices(indices);
             SearchResponse searchResponse = client.search(searchRequest);
             SearchHits hits = searchResponse.getHits();
             Iterator<SearchHit> hitsIt = hits.iterator();


### PR DESCRIPTION
Closes #145 

This subtle bug arose from a misunderstandng of the processing of pass.elsticsearch.url, which appended a path to the base url. Because the configuration of Elasticsearch required the HttpHost class, it took only the protocol, host and port information from the URL, and information about indices was ignored. As a result, no index was specified on searches, defaulting to a search of all indices on the host. This led to unexpected search results when indices were present in addition to the expected.

We added configuration for indices to be put on the SearchRequest in the ElasticsearchClent. The indices are a comma-separated list assigned as a value for the system property pass.elasticsearch.indices. 

This fix passes integration tests with the new default value of "http://localhost:9200" for pass.elasticsearch.url, and the default value of "pass" for the property pass.elaticsearch.indices. Integration tests fail with a different value set for the index to search, as the wait for updates to this index never happens.

